### PR TITLE
feat: retain platform fee on active escrow cancellation

### DIFF
--- a/apps/onchain/src/lib.rs
+++ b/apps/onchain/src/lib.rs
@@ -635,11 +635,27 @@ impl VaultixEscrow {
 
         if escrow.status == EscrowStatus::Active {
             let token_client = token::Client::new(&env, &escrow.token_address);
-            token_client.transfer(
-                &env.current_contract_address(),
-                &escrow.depositor,
-                &escrow.total_amount,
-            );
+
+            let refund_amount = if let Ok((treasury, fee_bps)) = Self::get_config(env.clone()) {
+                let fee = calculate_fee(escrow.total_amount, fee_bps)?;
+                if fee > 0 {
+                    token_client.transfer(&env.current_contract_address(), &treasury, &fee);
+                }
+                escrow
+                    .total_amount
+                    .checked_sub(fee)
+                    .ok_or(Error::InvalidMilestoneAmount)?
+            } else {
+                escrow.total_amount
+            };
+
+            if refund_amount > 0 {
+                token_client.transfer(
+                    &env.current_contract_address(),
+                    &escrow.depositor,
+                    &refund_amount,
+                );
+            }
         }
 
         escrow.status = EscrowStatus::Cancelled;
@@ -655,7 +671,7 @@ impl VaultixEscrow {
                 Symbol::new(&env, "EscrowCancelled"),
                 escrow_id,
             ),
-            escrow.depositor.clone(), // cancelled_by
+            escrow.depositor.clone(),
         );
 
         Ok(())


### PR DESCRIPTION
Description:
  ## Summary
  - Updated `cancel_escrow` to retain the platform fee when cancelling an `Active` escrow
  - If treasury is configured, the fee is transferred to treasury and the remainder refunded to the depositor
  - If no treasury is configured, full refund is issued (preserves existing behaviour)
  - `Created` escrows are unaffected — cleanup only, no funds to move

  ## Test plan
  - [ ] Existing `test_cancel_escrow_with_refund` — full refund when no treasury configured
  - [ ] Existing `test_cancel_unfunded_escrow` — Created status cleanup still works
  - [ ] New `test_cancel_active_escrow_retains_fee` — fee sent to treasury, remainder refunded to depositor
  
  closes #119 