### PR TITLE
fix(backend): add manual escrow expiration flow

### DIFF
--- a/apps/backend/src/modules/escrow/controllers/escrow.controller.ts
+++ b/apps/backend/src/modules/escrow/controllers/escrow.controller.ts
@@ -9,6 +9,7 @@ import {
   UseGuards,
   Request,
   Req,
+  ForbiddenException,
 } from '@nestjs/common';
 import { ThrottlerGuard } from '@nestjs/throttler';
 import { Request as ExpressRequest } from 'express';
@@ -20,6 +21,7 @@ import {
 } from '@nestjs/swagger';
 import { AuthGuard } from '../../auth/middleware/auth.guard';
 import { EscrowAccessGuard } from '../guards/escrow-access.guard';
+import { EscrowExpireGuard } from '../guards/escrow-expire.guard';
 import { EscrowService } from '../services/escrow.service';
 import { CreateEscrowDto } from '../dto/create-escrow.dto';
 import { UpdateEscrowDto } from '../dto/update-escrow.dto';
@@ -36,7 +38,7 @@ import { FundEscrowDto } from '../dto/fund-escrow.dto';
 import { ExpireEscrowDto } from '../dto/expire-escrow.dto';
 
 interface AuthenticatedRequest extends ExpressRequest {
-  user: { sub: string; walletAddress: string };
+  user: { sub?: string; userId?: string; walletAddress: string };
 }
 
 @Controller('escrows')
@@ -46,12 +48,21 @@ interface AuthenticatedRequest extends ExpressRequest {
 export class EscrowController {
   constructor(private readonly escrowService: EscrowService) {}
 
+  private getAuthenticatedUserId(req: AuthenticatedRequest): string {
+    const userId = req.user.sub ?? req.user.userId;
+    if (!userId) {
+      throw new ForbiddenException('User not authenticated');
+    }
+
+    return userId;
+  }
+
   @Post()
   async create(
     @Body() dto: CreateEscrowDto,
     @Request() req: AuthenticatedRequest,
   ) {
-    const userId = req.user.sub;
+    const userId = this.getAuthenticatedUserId(req);
     const ipAddress = req.ip || req.socket?.remoteAddress;
     return this.escrowService.create(dto, userId, ipAddress);
   }
@@ -61,7 +72,7 @@ export class EscrowController {
     @Query() query: ListEscrowsDto,
     @Request() req: AuthenticatedRequest,
   ) {
-    const userId = req.user.sub;
+    const userId = this.getAuthenticatedUserId(req);
     return this.escrowService.findAll(userId, query);
   }
 
@@ -74,7 +85,7 @@ export class EscrowController {
     @Query() query: EscrowOverviewQueryDto,
     @Request() req: AuthenticatedRequest,
   ) {
-    const userId = req.user.sub;
+    const userId = this.getAuthenticatedUserId(req);
     return this.escrowService.findOverview(userId, query);
   }
 
@@ -91,7 +102,7 @@ export class EscrowController {
     @Body() dto: UpdateEscrowDto,
     @Request() req: AuthenticatedRequest,
   ) {
-    const userId = req.user.sub;
+    const userId = this.getAuthenticatedUserId(req);
     const ipAddress = req.ip || req.socket?.remoteAddress;
     return this.escrowService.update(id, dto, userId, ipAddress);
   }
@@ -103,19 +114,19 @@ export class EscrowController {
     @Body() dto: CancelEscrowDto,
     @Request() req: AuthenticatedRequest,
   ) {
-    const userId = req.user.sub;
+    const userId = this.getAuthenticatedUserId(req);
     const ipAddress = req.ip || req.socket?.remoteAddress;
     return this.escrowService.cancel(id, dto, userId, ipAddress);
   }
 
   @Post(':id/expire')
-  @UseGuards(EscrowAccessGuard)
+  @UseGuards(EscrowExpireGuard)
   async expire(
     @Param('id') id: string,
     @Body() dto: ExpireEscrowDto,
     @Request() req: AuthenticatedRequest,
   ) {
-    const userId = req.user.sub;
+    const userId = this.getAuthenticatedUserId(req);
     const ipAddress = req.ip || req.socket?.remoteAddress;
 
     return this.escrowService.expire(id, dto, userId, ipAddress);
@@ -128,7 +139,7 @@ export class EscrowController {
     @Query() query: ListEventsDto,
     @Request() req: AuthenticatedRequest,
   ) {
-    const userId = req.user.sub;
+    const userId = this.getAuthenticatedUserId(req);
     return this.escrowService.findEvents(userId, query, id);
   }
 
@@ -143,7 +154,7 @@ export class EscrowController {
     return this.escrowService.fund(
       id,
       dto,
-      req.user.sub,
+      this.getAuthenticatedUserId(req),
       req.user.walletAddress,
       ipAddress,
     );
@@ -157,7 +168,7 @@ export class EscrowController {
   ) {
     const escrow = await this.escrowService.releaseEscrow(
       id,
-      req.user.sub,
+      this.getAuthenticatedUserId(req),
       true, // manual trigger
     );
 
@@ -176,7 +187,7 @@ export class EscrowController {
     @Body() dto: FulfillConditionDto,
     @Request() req: AuthenticatedRequest,
   ) {
-    const userId = req.user.sub;
+    const userId = this.getAuthenticatedUserId(req);
     const ipAddress = req.ip || req.socket?.remoteAddress;
     return this.escrowService.fulfillCondition(
       escrowId,
@@ -194,7 +205,7 @@ export class EscrowController {
     @Param('conditionId') conditionId: string,
     @Request() req: AuthenticatedRequest,
   ) {
-    const userId = req.user.sub;
+    const userId = this.getAuthenticatedUserId(req);
     const ipAddress = req.ip || req.socket?.remoteAddress;
     return this.escrowService.confirmCondition(
       escrowId,
@@ -217,7 +228,12 @@ export class EscrowController {
     @Request() req: AuthenticatedRequest,
   ) {
     const ipAddress = req.ip || req.socket?.remoteAddress;
-    return this.escrowService.fileDispute(id, req.user.sub, dto, ipAddress);
+    return this.escrowService.fileDispute(
+      id,
+      this.getAuthenticatedUserId(req),
+      dto,
+      ipAddress,
+    );
   }
 
   /**
@@ -243,6 +259,11 @@ export class EscrowController {
     @Request() req: AuthenticatedRequest,
   ) {
     const ipAddress = req.ip || req.socket?.remoteAddress;
-    return this.escrowService.resolveDispute(id, req.user.sub, dto, ipAddress);
+    return this.escrowService.resolveDispute(
+      id,
+      this.getAuthenticatedUserId(req),
+      dto,
+      ipAddress,
+    );
   }
 }

--- a/apps/backend/src/modules/escrow/escrow.module.ts
+++ b/apps/backend/src/modules/escrow/escrow.module.ts
@@ -12,15 +12,24 @@ import { EscrowController } from './controllers/escrow.controller';
 import { EscrowSchedulerController } from './controllers/escrow-scheduler.controller';
 import { EventsController } from './controllers/events.controller';
 import { EscrowAccessGuard } from './guards/escrow-access.guard';
+import { EscrowExpireGuard } from './guards/escrow-expire.guard';
 import { AuthModule } from '../auth/auth.module';
 import { StellarModule } from '../stellar/stellar.module';
 import { EscrowStellarIntegrationService } from './services/escrow-stellar-integration.service';
 import { WebhookModule } from '../webhook/webhook.module';
+import { User } from '../user/entities/user.entity';
 
 @Module({
   imports: [
     ScheduleModule.forRoot(),
-    TypeOrmModule.forFeature([Escrow, Party, Condition, EscrowEvent, Dispute]),
+    TypeOrmModule.forFeature([
+      Escrow,
+      Party,
+      Condition,
+      EscrowEvent,
+      Dispute,
+      User,
+    ]),
     AuthModule,
     StellarModule,
     WebhookModule,
@@ -31,6 +40,7 @@ import { WebhookModule } from '../webhook/webhook.module';
     EscrowSchedulerService,
     EscrowStellarIntegrationService,
     EscrowAccessGuard,
+    EscrowExpireGuard,
   ],
   exports: [EscrowService, EscrowSchedulerService],
 })

--- a/apps/backend/src/modules/escrow/guards/escrow-expire.guard.ts
+++ b/apps/backend/src/modules/escrow/guards/escrow-expire.guard.ts
@@ -1,0 +1,62 @@
+import {
+  CanActivate,
+  ExecutionContext,
+  ForbiddenException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common';
+import { Request } from 'express';
+import { Escrow } from '../entities/escrow.entity';
+import { EscrowService } from '../services/escrow.service';
+
+interface AuthUser {
+  sub?: string;
+  userId?: string;
+}
+
+interface AuthenticatedRequest extends Request {
+  user?: AuthUser;
+  params: { id?: string };
+  escrow?: Escrow;
+}
+
+@Injectable()
+export class EscrowExpireGuard implements CanActivate {
+  constructor(private readonly escrowService: EscrowService) {}
+
+  async canActivate(context: ExecutionContext): Promise<boolean> {
+    const request = context.switchToHttp().getRequest<AuthenticatedRequest>();
+    const actorId = request.user?.sub ?? request.user?.userId;
+    const escrowId = request.params.id;
+
+    if (!actorId) {
+      throw new ForbiddenException('User not authenticated');
+    }
+
+    if (!escrowId) {
+      return true;
+    }
+
+    const escrow = await this.escrowService.findOne(escrowId);
+    if (!escrow) {
+      throw new NotFoundException('Escrow not found');
+    }
+
+    request.escrow = escrow;
+
+    if (await this.escrowService.isUserAdmin(actorId)) {
+      return true;
+    }
+
+    const isParty = await this.escrowService.isUserPartyToEscrow(
+      escrowId,
+      actorId,
+    );
+
+    if (!isParty) {
+      throw new ForbiddenException('You do not have access to this escrow');
+    }
+
+    return true;
+  }
+}

--- a/apps/backend/src/modules/escrow/services/escrow-scheduler.service.ts
+++ b/apps/backend/src/modules/escrow/services/escrow-scheduler.service.ts
@@ -134,24 +134,14 @@ export class EscrowSchedulerService {
   private async autoCancelEscrow(escrow: Escrow) {
     this.logger.log(`Auto-expiring pending escrow: ${escrow.id}`);
 
-    escrow.status = EscrowStatus.EXPIRED;
-    escrow.isActive = false;
+    const expiredEscrow = await this.escrowService.expireBySystem(
+      escrow.id,
+      'EXPIRED_PENDING',
+    );
 
-    await this.escrowRepository.save(escrow);
-
-    await this.escrowEventRepository.save({
-      escrowId: escrow.id,
-      eventType: EscrowEventType.EXPIRED,
-      data: {
-        reason: 'EXPIRED_PENDING',
-        expiredAt: escrow.expiresAt,
-        processedAt: new Date(),
-      },
-    });
-
-    void this.notifyParties(escrow, 'ESCROW_EXPIRED', {
+    void this.notifyParties(expiredEscrow, 'ESCROW_EXPIRED', {
       reason: 'Escrow expired while pending',
-      expiredAt: escrow.expiresAt,
+      expiredAt: expiredEscrow.expiresAt,
     });
 
     this.logger.log(`Successfully expired pending escrow: ${escrow.id}`);
@@ -162,23 +152,14 @@ export class EscrowSchedulerService {
       `Escalating expired active escrow to expired status: ${escrow.id}`,
     );
 
-    escrow.status = EscrowStatus.EXPIRED;
+    const expiredEscrow = await this.escrowService.expireBySystem(
+      escrow.id,
+      'EXPIRED_ACTIVE',
+    );
 
-    await this.escrowRepository.save(escrow);
-
-    await this.escrowEventRepository.save({
-      escrowId: escrow.id,
-      eventType: EscrowEventType.EXPIRED,
-      data: {
-        reason: 'EXPIRED_ACTIVE',
-        expiredAt: escrow.expiresAt,
-        processedAt: new Date(),
-      },
-    });
-
-    void this.notifyParties(escrow, 'ESCROW_EXPIRED', {
+    void this.notifyParties(expiredEscrow, 'ESCROW_EXPIRED', {
       reason: 'Escrow expired while active',
-      expiredAt: escrow.expiresAt,
+      expiredAt: expiredEscrow.expiresAt,
       requiresArbitration: true,
     });
 

--- a/apps/backend/src/modules/escrow/services/escrow.service.spec.ts
+++ b/apps/backend/src/modules/escrow/services/escrow.service.spec.ts
@@ -29,6 +29,7 @@ import {
   EscrowOverviewStatus,
 } from '../dto/escrow-overview.dto';
 import { CreateEscrowDto } from '../dto/create-escrow.dto';
+import { User, UserRole } from '../../user/entities/user.entity';
 
 describe('EscrowService', () => {
   let service: EscrowService;
@@ -37,6 +38,8 @@ describe('EscrowService', () => {
   let conditionRepository: jest.Mocked<Repository<Condition>>;
   let eventRepository: jest.Mocked<Repository<EscrowEvent>>;
   let disputeRepository: jest.Mocked<Repository<Dispute>>;
+  let userRepository: jest.Mocked<Repository<User>>;
+  let webhookService: { dispatchEvent: jest.Mock };
 
   const mockEscrow: Partial<Escrow> = {
     id: 'escrow-123',
@@ -106,6 +109,10 @@ describe('EscrowService', () => {
       findOne: jest.fn(),
     };
 
+    const mockUserRepo = {
+      findOne: jest.fn(),
+    };
+
     const module: TestingModule = await Test.createTestingModule({
       providers: [
         EscrowService,
@@ -114,6 +121,7 @@ describe('EscrowService', () => {
         { provide: getRepositoryToken(Condition), useValue: mockConditionRepo },
         { provide: getRepositoryToken(EscrowEvent), useValue: mockEventRepo },
         { provide: getRepositoryToken(Dispute), useValue: mockDisputeRepo },
+        { provide: getRepositoryToken(User), useValue: mockUserRepo },
         {
           provide: EscrowStellarIntegrationService,
           useValue: {
@@ -136,6 +144,8 @@ describe('EscrowService', () => {
     conditionRepository = module.get(getRepositoryToken(Condition));
     eventRepository = module.get(getRepositoryToken(EscrowEvent));
     disputeRepository = module.get(getRepositoryToken(Dispute));
+    userRepository = module.get(getRepositoryToken(User));
+    webhookService = module.get(WebhookService);
   });
 
   it('should be defined', () => {
@@ -300,6 +310,149 @@ describe('EscrowService', () => {
       await expect(
         service.cancel('escrow-123', {}, 'other-user'),
       ).rejects.toThrow(ForbiddenException);
+    });
+  });
+
+  describe('expire', () => {
+    beforeEach(() => {
+      eventRepository.create.mockReturnValue({} as EscrowEvent);
+      eventRepository.save.mockResolvedValue({} as EscrowEvent);
+      userRepository.findOne.mockResolvedValue({
+        id: 'user-123',
+        role: UserRole.USER,
+      } as User);
+    });
+
+    it('should expire a pending escrow for the creator', async () => {
+      escrowRepository.findOne
+        .mockResolvedValueOnce(mockEscrow as Escrow)
+        .mockResolvedValueOnce({
+          ...mockEscrow,
+          status: EscrowStatus.EXPIRED,
+          isActive: false,
+        } as Escrow);
+      escrowRepository.update.mockResolvedValue({
+        affected: 1,
+      } as UpdateResult);
+
+      const result = await service.expire(
+        'escrow-123',
+        { reason: 'Manual cleanup' },
+        'user-123',
+        '127.0.0.1',
+      );
+
+      expect(escrowRepository.update).toHaveBeenCalledWith('escrow-123', {
+        status: EscrowStatus.EXPIRED,
+        isActive: false,
+      });
+      expect(eventRepository.save).toHaveBeenCalled();
+      expect(result.status).toBe(EscrowStatus.EXPIRED);
+    });
+
+    it('should allow an admin to expire an active escrow', async () => {
+      escrowRepository.findOne
+        .mockResolvedValueOnce({
+          ...mockEscrow,
+          status: EscrowStatus.ACTIVE,
+        } as Escrow)
+        .mockResolvedValueOnce({
+          ...mockEscrow,
+          status: EscrowStatus.EXPIRED,
+          isActive: false,
+        } as Escrow);
+      escrowRepository.update.mockResolvedValue({
+        affected: 1,
+      } as UpdateResult);
+      userRepository.findOne.mockResolvedValue({
+        id: 'admin-1',
+        role: UserRole.ADMIN,
+      } as User);
+
+      await service.expire(
+        'escrow-123',
+        { reason: 'Admin expired' },
+        'admin-1',
+      );
+
+      expect(escrowRepository.update).toHaveBeenCalledWith('escrow-123', {
+        status: EscrowStatus.EXPIRED,
+        isActive: false,
+      });
+    });
+
+    it('should throw ForbiddenException for non-creator non-admin users', async () => {
+      escrowRepository.findOne.mockResolvedValue(mockEscrow as Escrow);
+      userRepository.findOne.mockResolvedValue({
+        id: 'user-999',
+        role: UserRole.USER,
+      } as User);
+
+      await expect(
+        service.expire('escrow-123', {}, 'user-999'),
+      ).rejects.toThrow(ForbiddenException);
+    });
+
+    it('should throw BadRequestException when escrow is already terminal', async () => {
+      escrowRepository.findOne.mockResolvedValue({
+        ...mockEscrow,
+        status: EscrowStatus.COMPLETED,
+      } as Escrow);
+
+      await expect(
+        service.expire('escrow-123', {}, 'user-123'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should throw BadRequestException for non-expirable non-terminal states', async () => {
+      escrowRepository.findOne.mockResolvedValue({
+        ...mockEscrow,
+        status: EscrowStatus.DISPUTED,
+      } as Escrow);
+
+      await expect(
+        service.expire('escrow-123', {}, 'user-123'),
+      ).rejects.toThrow(BadRequestException);
+    });
+
+    it('should dispatch the expired webhook with the provided reason', async () => {
+      escrowRepository.findOne
+        .mockResolvedValueOnce(mockEscrow as Escrow)
+        .mockResolvedValueOnce({
+          ...mockEscrow,
+          status: EscrowStatus.EXPIRED,
+          isActive: false,
+        } as Escrow);
+      escrowRepository.update.mockResolvedValue({
+        affected: 1,
+      } as UpdateResult);
+
+      await service.expire(
+        'escrow-123',
+        { reason: 'User requested expiry' },
+        'user-123',
+        '10.0.0.8',
+      );
+
+      expect(webhookService.dispatchEvent).toHaveBeenCalledWith(
+        'escrow.expired',
+        {
+          escrowId: 'escrow-123',
+          reason: 'User requested expiry',
+        },
+      );
+      expect(eventRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          escrowId: 'escrow-123',
+          eventType: 'expired',
+          actorId: 'user-123',
+          ipAddress: '10.0.0.8',
+          data: expect.objectContaining({
+            reason: 'User requested expiry',
+            previousStatus: EscrowStatus.PENDING,
+          }),
+        }),
+      );
     });
   });
 

--- a/apps/backend/src/modules/escrow/services/escrow.service.ts
+++ b/apps/backend/src/modules/escrow/services/escrow.service.ts
@@ -38,6 +38,7 @@ import { ExpireEscrowDto } from '../dto/expire-escrow.dto';
 import { validateTransition, isTerminalStatus } from '../escrow-state-machine';
 import { EscrowStellarIntegrationService } from './escrow-stellar-integration.service';
 import { WebhookService } from '../../../services/webhook/webhook.service';
+import { User, UserRole } from '../../user/entities/user.entity';
 
 @Injectable()
 export class EscrowService {
@@ -52,6 +53,8 @@ export class EscrowService {
     private eventRepository: Repository<EscrowEvent>,
     @InjectRepository(Dispute)
     private disputeRepository: Repository<Dispute>,
+    @InjectRepository(User)
+    private userRepository: Repository<User>,
 
     private readonly stellarIntegrationService: EscrowStellarIntegrationService,
     private readonly webhookService: WebhookService,
@@ -406,44 +409,27 @@ export class EscrowService {
   ): Promise<Escrow> {
     const escrow = await this.findOne(id);
 
-    if (isTerminalStatus(escrow.status)) {
-      throw new BadRequestException(
-        `Cannot expire an escrow that is already ${escrow.status}`,
-      );
-    }
-
-    const isArbitrator = escrow.parties?.some(
-      (party) => party.role === PartyRole.ARBITRATOR && party.userId === userId,
-    );
-    if (escrow.creatorId !== userId && !isArbitrator) {
+    const isAdmin = await this.isUserAdmin(userId);
+    if (escrow.creatorId !== userId && !isAdmin) {
       throw new ForbiddenException(
-        'Only the creator or arbitrator can expire this escrow',
+        'Only the creator or an admin can expire this escrow',
       );
     }
 
-    validateTransition(escrow.status, EscrowStatus.EXPIRED);
-
-    await this.escrowRepository.update(id, {
-      status: EscrowStatus.EXPIRED,
-      isActive: false,
-    });
-
-    await this.logEvent(
-      id,
-      EscrowEventType.EXPIRED,
-      userId,
-      {
-        reason: dto.reason ?? 'Manually expired',
-        previousStatus: escrow.status,
-      },
+    return this.expireEscrow(escrow, {
+      actorId: userId,
       ipAddress,
-    );
-    await this.webhookService.dispatchEvent('escrow.expired', {
-      escrowId: id,
-      reason: dto.reason ?? null,
+      reason: dto.reason ?? 'Manually expired',
+      webhookReason: dto.reason ?? null,
     });
+  }
 
-    return this.findOne(id);
+  async expireBySystem(id: string, reason: string): Promise<Escrow> {
+    const escrow = await this.findOne(id);
+    return this.expireEscrow(escrow, {
+      reason,
+      webhookReason: reason,
+    });
   }
 
   async fund(
@@ -1033,7 +1019,7 @@ export class EscrowService {
   private async logEvent(
     escrowId: string,
     eventType: EscrowEventType,
-    actorId: string,
+    actorId?: string,
     data?: Record<string, any>,
     ipAddress?: string,
   ): Promise<EscrowEvent> {
@@ -1046,5 +1032,65 @@ export class EscrowService {
     });
 
     return this.eventRepository.save(event);
+  }
+
+  async isUserAdmin(userId: string): Promise<boolean> {
+    const user = await this.userRepository.findOne({
+      where: { id: userId },
+    });
+
+    return (
+      user?.role === UserRole.ADMIN || user?.role === UserRole.SUPER_ADMIN
+    );
+  }
+
+  private async expireEscrow(
+    escrow: Escrow,
+    options: {
+      actorId?: string;
+      ipAddress?: string;
+      reason: string;
+      webhookReason: string | null;
+    },
+  ): Promise<Escrow> {
+    if (isTerminalStatus(escrow.status)) {
+      throw new BadRequestException(
+        `Cannot expire an escrow that is already ${escrow.status}`,
+      );
+    }
+
+    if (
+      escrow.status !== EscrowStatus.PENDING &&
+      escrow.status !== EscrowStatus.ACTIVE
+    ) {
+      throw new BadRequestException(
+        'Escrow can only be expired while in pending or active status',
+      );
+    }
+
+    validateTransition(escrow.status, EscrowStatus.EXPIRED);
+
+    await this.escrowRepository.update(escrow.id, {
+      status: EscrowStatus.EXPIRED,
+      isActive: false,
+    });
+
+    await this.logEvent(
+      escrow.id,
+      EscrowEventType.EXPIRED,
+      options.actorId,
+      {
+        reason: options.reason,
+        previousStatus: escrow.status,
+      },
+      options.ipAddress,
+    );
+
+    await this.webhookService.dispatchEvent('escrow.expired', {
+      escrowId: escrow.id,
+      reason: options.webhookReason,
+    });
+
+    return this.findOne(escrow.id);
   }
 }


### PR DESCRIPTION
Closes #149

---

## Summary
This PR fixes the missing manual escrow expiration flow by implementing `expire()` in `EscrowService` and wiring the endpoint to a permission model that matches the product requirement.

Previously, the expire endpoint called into a service path that was either missing in the target task context or inconsistent with the expected behavior. This PR adds the manual expire flow, ensures only the escrow creator or an admin can trigger it, validates allowed status transitions through the existing state machine, logs the expiration event, dispatches the `escrow.expired` webhook, and aligns scheduler-based expiration with the same core behavior.

## Changes
- Implemented `expire(id, dto, userId, ipAddress)` in `EscrowService`
- Added permission validation so only the escrow creator or an admin can manually expire an escrow
- Restricted manual expiration to valid non-terminal expirable states: `PENDING` and `ACTIVE`
- Reused `validateTransition()` to enforce the `-> EXPIRED` state change
- Logged `EXPIRED` events with actor, IP address, and previous status
- Dispatched `escrow.expired` webhook on manual expiration
- Added shared expiration logic so scheduler expiration and manual expiration stay behaviorally consistent
- Added `EscrowExpireGuard` so admins can access the manual expire endpoint without being blocked by party-only escrow access rules
- Added unit tests covering success and failure paths for manual expiration

## Why
The controller’s manual expire endpoint needed a real backend implementation and the access model needed to match the requirement of `creator or admin`. There was also a consistency gap between scheduler expiration and manual expiration, especially around status updates, event logging, and webhook dispatch.

## Testing
- `npx.cmd tsc --noEmit -p tsconfig.json`
- `npm.cmd test -- escrow.service.spec.ts --runInBand`

## Acceptance Criteria Coverage
- Implement `expire(id, dto, userId, ipAddress)` method in `EscrowService`
- Validate that only the escrow creator or an admin can manually expire an escrow
- Validate the escrow is in a state that allows expiration (`PENDING` or `ACTIVE`, not terminal)
- Use the existing state machine (`validateTransition`) for status change validation
- Log an `EXPIRED` event with actor and IP address
- Dispatch `escrow.expired` webhook event
- Add unit tests for the new method covering success and error paths
- Ensure scheduler automatic expiration and manual expiration are consistent in behavior

## Notes
- Root `package-lock.json` changes from dependency installation were intentionally excluded from the commit to keep the PR focused on the backend escrow fix only.