### PR TITLE
feat: dynamic tier-based fee structure (#132)

### DIFF
--- a/apps/onchain/src/fee_tests.rs
+++ b/apps/onchain/src/fee_tests.rs
@@ -512,3 +512,285 @@ fn test_max_fee_10000_bps_valid() {
     let result = client.try_set_token_fee(&token_address, &10000);
     assert!(result.is_ok());
 }
+
+// ---------------------------------------------------------------------------
+// Tiered fee tests (issue #132)
+// ---------------------------------------------------------------------------
+
+/// Tier 1: amount < 10_000_000_000 (< 1,000 XLM) → 50 bps
+/// When initialized without an explicit fee (None), tiers apply.
+#[test]
+fn test_tiered_fee_tier1_low_volume() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, VaultixEscrow);
+    let client = VaultixEscrowClient::new(&env, &contract_id);
+
+    let treasury = Address::generate(&env);
+    // No explicit fee → tiered defaults apply
+    client.initialize(&treasury, &None);
+
+    let depositor = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let admin = Address::generate(&env);
+
+    let (token_client, token_admin, token_address) = create_token_contract(&env, &admin);
+    // 5_000 tokens — well below Tier 1 threshold (10_000_000_000)
+    let amount = 5_000i128;
+    token_admin.mint(&depositor, &amount);
+
+    let escrow_id = 200u64;
+    let milestones = vec![
+        &env,
+        Milestone {
+            amount,
+            status: MilestoneStatus::Pending,
+            description: symbol_short!("Work"),
+        },
+    ];
+
+    client.create_escrow(
+        &escrow_id,
+        &depositor,
+        &recipient,
+        &token_address,
+        &milestones,
+        &(env.ledger().timestamp() + 3600),
+    );
+
+    token_client.approve(&depositor, &contract_id, &amount, &200);
+    client.deposit_funds(&escrow_id);
+    client.release_milestone(&escrow_id, &0);
+
+    // Tier 1 → 50 bps: fee = 5_000 * 50 / 10_000 = 25
+    let expected_fee = 25i128;
+    let expected_payout = amount - expected_fee;
+
+    assert_eq!(token_client.balance(&recipient), expected_payout);
+    assert_eq!(token_client.balance(&treasury), expected_fee);
+}
+
+/// Tier 2: 10_000_000_000 ≤ amount < 50_000_000_000 → 30 bps
+#[test]
+fn test_tiered_fee_tier2_medium_volume() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, VaultixEscrow);
+    let client = VaultixEscrowClient::new(&env, &contract_id);
+
+    let treasury = Address::generate(&env);
+    client.initialize(&treasury, &None);
+
+    let depositor = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let admin = Address::generate(&env);
+
+    let (token_client, token_admin, token_address) = create_token_contract(&env, &admin);
+    // 20_000_000_000 tokens — in the Tier 2 range (1,000–5,000 XLM)
+    let amount = 20_000_000_000i128;
+    token_admin.mint(&depositor, &amount);
+
+    let escrow_id = 201u64;
+    let milestones = vec![
+        &env,
+        Milestone {
+            amount,
+            status: MilestoneStatus::Pending,
+            description: symbol_short!("Work"),
+        },
+    ];
+
+    client.create_escrow(
+        &escrow_id,
+        &depositor,
+        &recipient,
+        &token_address,
+        &milestones,
+        &(env.ledger().timestamp() + 3600),
+    );
+
+    // Raise threshold so depositor-only auth path is used (avoid multi-sig requirement)
+    client.configure_multisig(&escrow_id, &i128::MAX, &1);
+
+    token_client.approve(&depositor, &contract_id, &amount, &200);
+    client.deposit_funds(&escrow_id);
+    client.release_milestone(&escrow_id, &0);
+
+    // Tier 2 → 30 bps: fee = 20_000_000_000 * 30 / 10_000 = 60_000_000
+    let expected_fee = 60_000_000i128;
+    let expected_payout = amount - expected_fee;
+
+    assert_eq!(token_client.balance(&recipient), expected_payout);
+    assert_eq!(token_client.balance(&treasury), expected_fee);
+}
+
+/// Tier 3: amount ≥ 50_000_000_000 → 10 bps
+#[test]
+fn test_tiered_fee_tier3_high_volume() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, VaultixEscrow);
+    let client = VaultixEscrowClient::new(&env, &contract_id);
+
+    let treasury = Address::generate(&env);
+    client.initialize(&treasury, &None);
+
+    let depositor = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let admin = Address::generate(&env);
+
+    let (token_client, token_admin, token_address) = create_token_contract(&env, &admin);
+    // 100_000_000_000 tokens — above Tier 3 threshold (> 5,000 XLM)
+    let amount = 100_000_000_000i128;
+    token_admin.mint(&depositor, &amount);
+
+    let escrow_id = 202u64;
+    let milestones = vec![
+        &env,
+        Milestone {
+            amount,
+            status: MilestoneStatus::Pending,
+            description: symbol_short!("Work"),
+        },
+    ];
+
+    client.create_escrow(
+        &escrow_id,
+        &depositor,
+        &recipient,
+        &token_address,
+        &milestones,
+        &(env.ledger().timestamp() + 3600),
+    );
+
+    // Raise threshold so depositor-only auth path is used
+    client.configure_multisig(&escrow_id, &i128::MAX, &1);
+
+    token_client.approve(&depositor, &contract_id, &amount, &200);
+    client.deposit_funds(&escrow_id);
+    client.release_milestone(&escrow_id, &0);
+
+    // Tier 3 → 10 bps: fee = 100_000_000_000 * 10 / 10_000 = 100_000_000
+    let expected_fee = 100_000_000i128;
+    let expected_payout = amount - expected_fee;
+
+    assert_eq!(token_client.balance(&recipient), expected_payout);
+    assert_eq!(token_client.balance(&treasury), expected_fee);
+}
+
+/// Explicit global fee override takes priority over tiers.
+#[test]
+fn test_explicit_global_fee_overrides_tiers() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, VaultixEscrow);
+    let client = VaultixEscrowClient::new(&env, &contract_id);
+
+    let treasury = Address::generate(&env);
+    // Explicit 100 bps override — even for a Tier 3 amount this should apply
+    client.initialize(&treasury, &Some(100));
+
+    let depositor = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let admin = Address::generate(&env);
+
+    let (token_client, token_admin, token_address) = create_token_contract(&env, &admin);
+    // High-volume amount that would normally land in Tier 3 (10 bps)
+    let amount = 100_000_000_000i128;
+    token_admin.mint(&depositor, &amount);
+
+    let escrow_id = 203u64;
+    let milestones = vec![
+        &env,
+        Milestone {
+            amount,
+            status: MilestoneStatus::Pending,
+            description: symbol_short!("Work"),
+        },
+    ];
+
+    client.create_escrow(
+        &escrow_id,
+        &depositor,
+        &recipient,
+        &token_address,
+        &milestones,
+        &(env.ledger().timestamp() + 3600),
+    );
+
+    // Raise threshold so depositor-only auth path is used
+    client.configure_multisig(&escrow_id, &i128::MAX, &1);
+
+    token_client.approve(&depositor, &contract_id, &amount, &200);
+    client.deposit_funds(&escrow_id);
+    client.release_milestone(&escrow_id, &0);
+
+    // Global override (100 bps) wins: fee = 100_000_000_000 * 100 / 10_000 = 1_000_000_000
+    let expected_fee = 1_000_000_000i128;
+    let expected_payout = amount - expected_fee;
+
+    assert_eq!(token_client.balance(&recipient), expected_payout);
+    assert_eq!(token_client.balance(&treasury), expected_fee);
+}
+
+/// Escrow-level override takes priority over tiers even for high-volume amounts.
+#[test]
+fn test_escrow_fee_override_takes_priority_over_tiers() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, VaultixEscrow);
+    let client = VaultixEscrowClient::new(&env, &contract_id);
+
+    let treasury = Address::generate(&env);
+    client.initialize(&treasury, &None); // tiers as default
+
+    let depositor = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let admin = Address::generate(&env);
+
+    let (token_client, token_admin, token_address) = create_token_contract(&env, &admin);
+    // Tier 3 amount
+    let amount = 100_000_000_000i128;
+    token_admin.mint(&depositor, &amount);
+
+    let escrow_id = 204u64;
+    // Set explicit escrow-level fee of 200 bps (overrides Tier 3's 10 bps)
+    client.set_escrow_fee(&escrow_id, &200);
+
+    let milestones = vec![
+        &env,
+        Milestone {
+            amount,
+            status: MilestoneStatus::Pending,
+            description: symbol_short!("Work"),
+        },
+    ];
+
+    client.create_escrow(
+        &escrow_id,
+        &depositor,
+        &recipient,
+        &token_address,
+        &milestones,
+        &(env.ledger().timestamp() + 3600),
+    );
+
+    // Raise threshold so depositor-only auth path is used
+    client.configure_multisig(&escrow_id, &i128::MAX, &1);
+
+    token_client.approve(&depositor, &contract_id, &amount, &200);
+    client.deposit_funds(&escrow_id);
+    client.release_milestone(&escrow_id, &0);
+
+    // Escrow override (200 bps): fee = 100_000_000_000 * 200 / 10_000 = 2_000_000_000
+    let expected_fee = 2_000_000_000i128;
+    let expected_payout = amount - expected_fee;
+
+    assert_eq!(token_client.balance(&recipient), expected_payout);
+    assert_eq!(token_client.balance(&treasury), expected_fee);
+}

--- a/apps/onchain/src/lib.rs
+++ b/apps/onchain/src/lib.rs
@@ -128,6 +128,16 @@ pub enum Error {
 const DEFAULT_FEE_BPS: i128 = 50;
 const BPS_DENOMINATOR: i128 = 10000;
 
+// Dynamic tier-based fee thresholds (in token base units, e.g. XLM stroops: 1 XLM = 10_000_000)
+// Tier 1: 0 – 1,000 XLM  → 50 bps (0.50%)
+// Tier 2: 1,000 – 5,000 XLM → 30 bps (0.30%)
+// Tier 3: > 5,000 XLM    → 10 bps (0.10%)
+const FEE_TIER_1_THRESHOLD: i128 = 10_000_000_000; // 1,000 XLM in stroops
+const FEE_TIER_2_THRESHOLD: i128 = 50_000_000_000; // 5,000 XLM in stroops
+const FEE_TIER_1_BPS: i128 = 50; // 0.50% for low-volume escrows
+const FEE_TIER_2_BPS: i128 = 30; // 0.30% for medium-volume escrows
+const FEE_TIER_3_BPS: i128 = 10; // 0.10% for high-volume escrows
+
 #[contract]
 pub struct VaultixEscrow;
 
@@ -136,18 +146,9 @@ impl VaultixEscrow {
     pub fn initialize(env: Env, treasury: Address, fee_bps: Option<i128>) -> Result<(), Error> {
         treasury.require_auth();
 
-        let fee = fee_bps.unwrap_or(DEFAULT_FEE_BPS);
-
-        if !(0..=BPS_DENOMINATOR).contains(&fee) {
-            return Err(Error::InvalidFeeConfiguration);
-        }
-
         env.storage()
             .instance()
             .set(&symbol_short!("treasury"), &treasury);
-        env.storage()
-            .instance()
-            .set(&symbol_short!("fee_bps"), &fee);
 
         let vaultix_topic = Symbol::new(&env, "Vaultix");
 
@@ -161,16 +162,28 @@ impl VaultixEscrow {
             (Option::<Address>::None, treasury.clone()),
         );
 
-        // Emit FeeUpdated(scope, key, old_fee, new_fee)
-        env.events().publish(
-            (vaultix_topic, Symbol::new(&env, "FeeUpdated")),
-            (
-                Symbol::new(&env, "Global"),
-                Symbol::new(&env, "PlatformFee"),
-                0i128,
-                fee,
-            ),
-        );
+        // Only store an explicit global fee override; passing None defers to the
+        // dynamic tier-based fee schedule (see get_tiered_fee_bps / calculate_tiered_fee).
+        if let Some(fee) = fee_bps {
+            if !(0..=BPS_DENOMINATOR).contains(&fee) {
+                return Err(Error::InvalidFeeConfiguration);
+            }
+
+            env.storage()
+                .instance()
+                .set(&symbol_short!("fee_bps"), &fee);
+
+            // Emit FeeUpdated(scope, key, old_fee, new_fee)
+            env.events().publish(
+                (vaultix_topic, Symbol::new(&env, "FeeUpdated")),
+                (
+                    Symbol::new(&env, "Global"),
+                    Symbol::new(&env, "PlatformFee"),
+                    0i128,
+                    fee,
+                ),
+            );
+        }
 
         Ok(())
     }
@@ -640,7 +653,7 @@ impl VaultixEscrow {
         }
 
         let (treasury, _) = Self::get_config(env.clone())?;
-        let fee_bps = resolve_fee(&env, escrow_id, &escrow.token_address)?;
+        let fee_bps = resolve_fee(&env, escrow_id, &escrow.token_address, milestone.amount)?;
         let fee = calculate_fee(milestone.amount, fee_bps)?;
         let payout = milestone
             .amount
@@ -992,7 +1005,7 @@ impl VaultixEscrow {
         if escrow.status == EscrowStatus::Active {
             let token_client = token::Client::new(&env, &escrow.token_address);
             let refund_amount = if let Ok((treasury, _)) = Self::get_config(env.clone()) {
-                let fee_bps = resolve_fee(&env, escrow_id, &escrow.token_address)?;
+                let fee_bps = resolve_fee(&env, escrow_id, &escrow.token_address, escrow.total_amount)?;
                 let fee = calculate_fee(escrow.total_amount, fee_bps)?;
                 // Debug: fee resolved
                 env.events().publish(
@@ -1144,8 +1157,8 @@ impl VaultixEscrow {
         // Retrieve platform fee BPS from contract configuration
         let (treasury, _) = Self::get_config(env.clone())?;
 
-        // Resolve fee with precedence: escrow > token > global
-        let fee_bps = resolve_fee(&env, escrow_id, &escrow.token_address)?;
+        // Resolve fee with precedence: escrow > token > global override > tiers
+        let fee_bps = resolve_fee(&env, escrow_id, &escrow.token_address, remaining_balance)?;
 
         // Calculate platform fee using checked arithmetic
         let platform_fee = calculate_fee(remaining_balance, fee_bps)?;
@@ -1226,7 +1239,25 @@ fn get_escrow_fee_key(escrow_id: u64) -> (Symbol, u64) {
 ///
 /// # Returns
 /// The fee in basis points to apply for the transaction
-fn resolve_fee(env: &Env, escrow_id: u64, token_address: &Address) -> Result<i128, Error> {
+/// Returns the fee basis points for the given amount based on volume tiers.
+/// Higher-volume escrows receive progressively lower fee rates.
+fn get_tiered_fee_bps(amount: i128) -> i128 {
+    if amount < FEE_TIER_1_THRESHOLD {
+        FEE_TIER_1_BPS
+    } else if amount < FEE_TIER_2_THRESHOLD {
+        FEE_TIER_2_BPS
+    } else {
+        FEE_TIER_3_BPS
+    }
+}
+
+/// Calculate the platform fee using the dynamic tier-based rate for the given amount.
+fn calculate_tiered_fee(amount: i128) -> Result<i128, Error> {
+    let fee_bps = get_tiered_fee_bps(amount);
+    calculate_fee(amount, fee_bps)
+}
+
+fn resolve_fee(env: &Env, escrow_id: u64, token_address: &Address, amount: i128) -> Result<i128, Error> {
     // Check escrow-specific override first (highest priority)
     let escrow_fee_key = get_escrow_fee_key(escrow_id);
     if let Some(escrow_fee) = env
@@ -1247,14 +1278,17 @@ fn resolve_fee(env: &Env, escrow_id: u64, token_address: &Address) -> Result<i12
         return Ok(token_fee);
     }
 
-    // Fall back to global default fee
-    let global_fee: i128 = env
+    // Check for an explicit global fee override set by admin
+    if let Some(global_fee) = env
         .storage()
         .instance()
-        .get(&symbol_short!("fee_bps"))
-        .unwrap_or(DEFAULT_FEE_BPS);
+        .get::<_, i128>(&symbol_short!("fee_bps"))
+    {
+        return Ok(global_fee);
+    }
 
-    Ok(global_fee)
+    // Fall back to dynamic tiered fee based on amount
+    Ok(get_tiered_fee_bps(amount))
 }
 
 /// Safely transfer tokens from `from` to `to`, returning an error if balance is insufficient.

--- a/apps/onchain/src/lib.rs
+++ b/apps/onchain/src/lib.rs
@@ -1005,7 +1005,8 @@ impl VaultixEscrow {
         if escrow.status == EscrowStatus::Active {
             let token_client = token::Client::new(&env, &escrow.token_address);
             let refund_amount = if let Ok((treasury, _)) = Self::get_config(env.clone()) {
-                let fee_bps = resolve_fee(&env, escrow_id, &escrow.token_address, escrow.total_amount)?;
+                let fee_bps =
+                    resolve_fee(&env, escrow_id, &escrow.token_address, escrow.total_amount)?;
                 let fee = calculate_fee(escrow.total_amount, fee_bps)?;
                 // Debug: fee resolved
                 env.events().publish(
@@ -1257,7 +1258,12 @@ fn calculate_tiered_fee(amount: i128) -> Result<i128, Error> {
     calculate_fee(amount, fee_bps)
 }
 
-fn resolve_fee(env: &Env, escrow_id: u64, token_address: &Address, amount: i128) -> Result<i128, Error> {
+fn resolve_fee(
+    env: &Env,
+    escrow_id: u64,
+    token_address: &Address,
+    amount: i128,
+) -> Result<i128, Error> {
     // Check escrow-specific override first (highest priority)
     let escrow_fee_key = get_escrow_fee_key(escrow_id);
     if let Some(escrow_fee) = env


### PR DESCRIPTION
## Summary

- Replaces the static `fee_bps` global fallback with a three-tier fee schedule that lowers platform fees as escrow volume increases
- Adds `get_tiered_fee_bps()` and `calculate_tiered_fee()` helper functions
- Updates `resolve_fee()` to accept the escrow amount and use tiers as the ultimate fallback (priority: escrow override → token override → admin global override → tiers)
- Updates `initialize()` so passing `None` defers to the tier schedule instead of storing `DEFAULT_FEE_BPS` as a blocking global override

**Tier schedule (token base units / XLM stroops):**
| Tier | Amount range | Fee |
|------|-------------|-----|
| 1 | < 1,000 XLM (< 10_000_000_000) | 50 bps (0.50%) |
| 2 | 1,000–5,000 XLM | 30 bps (0.30%) |
| 3 | > 5,000 XLM (≥ 50_000_000_000) | 10 bps (0.10%) |

## Test plan

- [x] `test_tiered_fee_tier1_low_volume` — small amount uses 50 bps
- [x] `test_tiered_fee_tier2_medium_volume` — mid-range amount uses 30 bps
- [x] `test_tiered_fee_tier3_high_volume` — large amount uses 10 bps
- [x] `test_explicit_global_fee_overrides_tiers` — admin global override beats tiers
- [x] `test_escrow_fee_override_takes_priority_over_tiers` — escrow override beats tiers
- [x] All 64 existing tests continue to pass

Closes #132