### PR TITLE
 feat(onchain): add atomic batch escrow creation + packed storage TTL

### DIFF
--- a/apps/onchain/src/lib.rs
+++ b/apps/onchain/src/lib.rs
@@ -39,7 +39,7 @@ pub enum MilestoneStatus {
 }
 
 #[contracttype]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Milestone {
     pub amount: i128,
     pub status: MilestoneStatus,
@@ -75,7 +75,7 @@ pub enum ContractState {
 }
 
 #[contracttype]
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq)]
 pub struct Escrow {
     pub depositor: Address,
     pub recipient: Address,
@@ -89,6 +89,45 @@ pub struct Escrow {
     pub threshold_amount: i128, // Threshold amount for multi-sig requirement
     pub required_signatures: u32, // Number of signatures required for release
     pub collected_signatures: Vec<Address>, // Addresses that have signed for release
+}
+
+#[contracttype]
+#[derive(Clone, Debug)]
+struct EscrowEntryV2 {
+    depositor: Address,
+    recipient: Address,
+    token_address: Address,
+    total_amount: i128,
+    total_released: i128,
+    milestones: Vec<Milestone>,
+    packed_state: u32,
+    deadline: u64,
+    threshold_amount: i128,
+    required_signatures: u32,
+    collected_signatures: Vec<Address>,
+    fee_override_bps: i128,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct CreateEscrowRequest {
+    pub escrow_id: u64,
+    pub depositor: Address,
+    pub recipient: Address,
+    pub token_address: Address,
+    pub milestones: Vec<Milestone>,
+    pub deadline: u64,
+}
+
+#[contracttype]
+#[derive(Clone, Debug, PartialEq)]
+pub struct EscrowCreatedBatchItem {
+    pub escrow_id: u64,
+    pub depositor: Address,
+    pub recipient: Address,
+    pub token_address: Address,
+    pub total_amount: i128,
+    pub deadline: u64,
 }
 
 #[contracterror]
@@ -235,6 +274,9 @@ impl VaultixEscrow {
         let old_fee: Option<i128> = env.storage().persistent().get(&token_fee_key);
 
         env.storage().persistent().set(&token_fee_key, &fee_bps);
+        env.storage()
+            .persistent()
+            .extend_ttl(&token_fee_key, 100, 2_000_000);
 
         // Emit FeeUpdated event for token-level override
         env.events().publish(
@@ -275,10 +317,29 @@ impl VaultixEscrow {
             return Err(Error::InvalidFeeConfiguration);
         }
 
+        if let Ok(mut escrow) = load_escrow_entry_v2(&env, escrow_id) {
+            let old_fee = escrow_fee_override_opt(&escrow).unwrap_or(DEFAULT_FEE_BPS);
+            escrow.fee_override_bps = fee_bps;
+            store_escrow_entry_v2(&env, escrow_id, &escrow);
+
+            env.events().publish(
+                (
+                    Symbol::new(&env, "Vaultix"),
+                    Symbol::new(&env, "FeeUpdated"),
+                ),
+                (Symbol::new(&env, "Escrow"), escrow_id, old_fee, fee_bps),
+            );
+
+            return Ok(());
+        }
+
         let escrow_fee_key = get_escrow_fee_key(escrow_id);
         let old_fee: Option<i128> = env.storage().persistent().get(&escrow_fee_key);
 
         env.storage().persistent().set(&escrow_fee_key, &fee_bps);
+        env.storage()
+            .persistent()
+            .extend_ttl(&escrow_fee_key, 100, 500_000);
 
         // Emit FeeUpdated event for escrow-level override
         env.events().publish(
@@ -350,10 +411,11 @@ impl VaultixEscrow {
         env.storage().persistent().set(&admin_storage_key(), &admin);
         env.storage()
             .persistent()
-            .set(&Symbol::new(&env, "operator"), &operator);
+            .set(&operator_storage_key(), &operator);
         env.storage()
             .persistent()
-            .set(&Symbol::new(&env, "arbitrator"), &arbitrator);
+            .set(&arbitrator_storage_key(), &arbitrator);
+        extend_roles_ttl(&env);
 
         let vaultix_topic = Symbol::new(&env, "Vaultix");
 
@@ -393,26 +455,21 @@ impl VaultixEscrow {
         threshold_amount: i128,
         required_signatures: u32,
     ) -> Result<(), Error> {
-        let storage_key = get_storage_key(escrow_id);
         ensure_not_paused(&env)?;
 
-        let mut escrow: Escrow = env
-            .storage()
-            .persistent()
-            .get(&storage_key)
-            .ok_or(Error::EscrowNotFound)?;
+        let mut escrow = load_escrow_entry_v2(&env, escrow_id)?;
 
         escrow.depositor.require_auth();
 
         // Only allow configuration if the escrow hasn't been funded yet
-        if escrow.status != EscrowStatus::Created {
+        if escrow_status(&escrow) != EscrowStatus::Created {
             return Err(Error::InvalidEscrowStatus);
         }
 
         escrow.threshold_amount = threshold_amount;
         escrow.required_signatures = required_signatures;
 
-        env.storage().persistent().set(&storage_key, &escrow);
+        store_escrow_entry_v2(&env, escrow_id, &escrow);
 
         // Emit event
         env.events().publish(
@@ -443,8 +500,15 @@ impl VaultixEscrow {
             return Err(Error::SelfDealing);
         }
 
-        let storage_key = get_storage_key(escrow_id);
-        if env.storage().persistent().has(&storage_key) {
+        if env
+            .storage()
+            .persistent()
+            .has(&get_storage_key_legacy(escrow_id))
+            || env
+                .storage()
+                .persistent()
+                .has(&get_storage_key_v2(escrow_id))
+        {
             return Err(Error::EscrowAlreadyExists);
         }
 
@@ -457,25 +521,33 @@ impl VaultixEscrow {
             initialized_milestones.push_back(m);
         }
 
-        let escrow = Escrow {
+        let fee_override_bps = env
+            .storage()
+            .persistent()
+            .get::<(Symbol, u64), i128>(&get_escrow_fee_key(escrow_id))
+            .unwrap_or(-1);
+        if fee_override_bps >= 0 {
+            env.storage()
+                .persistent()
+                .remove(&get_escrow_fee_key(escrow_id));
+        }
+
+        let escrow = EscrowEntryV2 {
             depositor: depositor.clone(),
             recipient: recipient.clone(),
             token_address: token_address.clone(),
             total_amount,
             total_released: 0,
             milestones: initialized_milestones,
-            status: EscrowStatus::Created,
+            packed_state: pack_escrow_state(EscrowStatus::Created, Resolution::None),
             deadline,
-            resolution: Resolution::None,
-            threshold_amount: 10000, // Default threshold amount (configurable)
-            required_signatures: 1,  // Default to single signature
+            threshold_amount: 10000,
+            required_signatures: 1,
             collected_signatures: Vec::new(&env),
+            fee_override_bps,
         };
 
-        env.storage().persistent().set(&storage_key, &escrow);
-        env.storage()
-            .persistent()
-            .extend_ttl(&storage_key, 100, 2_000_000);
+        store_escrow_entry_v2(&env, escrow_id, &escrow);
 
         // Standardized Event
         env.events().publish(
@@ -490,18 +562,137 @@ impl VaultixEscrow {
         Ok(())
     }
 
-    pub fn deposit_funds(env: Env, escrow_id: u64) -> Result<(), Error> {
-        let storage_key = get_storage_key(escrow_id);
+    pub fn create_escrows_batch(env: Env, requests: Vec<CreateEscrowRequest>) -> Result<(), Error> {
         ensure_not_paused(&env)?;
 
-        let mut escrow: Escrow = env
-            .storage()
-            .persistent()
-            .get(&storage_key)
-            .ok_or(Error::EscrowNotFound)?;
+        if requests.len() > 20 {
+            return Err(Error::VectorTooLarge);
+        }
+
+        let mut created_items: Vec<EscrowCreatedBatchItem> = Vec::new(&env);
+        let mut pending_entries: Vec<(u64, EscrowEntryV2, bool)> = Vec::new(&env);
+        let mut escrow_ids: Vec<u64> = Vec::new(&env);
+        let mut authed: Vec<Address> = Vec::new(&env);
+
+        for request in requests.iter() {
+            let escrow_id = request.escrow_id;
+            let depositor = request.depositor.clone();
+            let recipient = request.recipient.clone();
+            let token_address = request.token_address.clone();
+            let milestones = request.milestones.clone();
+            let deadline = request.deadline;
+
+            if depositor == recipient {
+                return Err(Error::SelfDealing);
+            }
+
+            for existing_id in escrow_ids.iter() {
+                if existing_id == escrow_id {
+                    return Err(Error::EscrowAlreadyExists);
+                }
+            }
+            escrow_ids.push_back(escrow_id);
+
+            if env
+                .storage()
+                .persistent()
+                .has(&get_storage_key_legacy(escrow_id))
+                || env
+                    .storage()
+                    .persistent()
+                    .has(&get_storage_key_v2(escrow_id))
+            {
+                return Err(Error::EscrowAlreadyExists);
+            }
+
+            let mut already_authed = false;
+            for a in authed.iter() {
+                if a == depositor {
+                    already_authed = true;
+                    break;
+                }
+            }
+            if !already_authed {
+                depositor.require_auth();
+                authed.push_back(depositor.clone());
+            }
+
+            let total_amount = validate_milestones(&milestones)?;
+
+            let mut initialized_milestones = Vec::new(&env);
+            for milestone in milestones.iter() {
+                let mut m = milestone.clone();
+                m.status = MilestoneStatus::Pending;
+                initialized_milestones.push_back(m);
+            }
+
+            let fee_override_bps = env
+                .storage()
+                .persistent()
+                .get::<(Symbol, u64), i128>(&get_escrow_fee_key(escrow_id))
+                .unwrap_or(-1);
+
+            let escrow = EscrowEntryV2 {
+                depositor: depositor.clone(),
+                recipient: recipient.clone(),
+                token_address: token_address.clone(),
+                total_amount,
+                total_released: 0,
+                milestones: initialized_milestones,
+                packed_state: pack_escrow_state(EscrowStatus::Created, Resolution::None),
+                deadline,
+                threshold_amount: 10000,
+                required_signatures: 1,
+                collected_signatures: Vec::new(&env),
+                fee_override_bps,
+            };
+
+            pending_entries.push_back((escrow_id, escrow, fee_override_bps >= 0));
+
+            created_items.push_back(EscrowCreatedBatchItem {
+                escrow_id,
+                depositor,
+                recipient,
+                token_address,
+                total_amount,
+                deadline,
+            });
+        }
+
+        for pending in pending_entries.iter() {
+            let escrow_id = pending.0;
+            let escrow = pending.1.clone();
+            let has_fee_key = pending.2;
+
+            if has_fee_key {
+                env.storage()
+                    .persistent()
+                    .remove(&get_escrow_fee_key(escrow_id));
+            }
+
+            store_escrow_entry_v2(&env, escrow_id, &escrow);
+        }
+
+        if !created_items.is_empty() {
+            env.events().publish(
+                (
+                    Symbol::new(&env, "Vaultix"),
+                    Symbol::new(&env, "EscrowsCreatedBatch"),
+                ),
+                created_items,
+            );
+        }
+
+        Ok(())
+    }
+
+    pub fn deposit_funds(env: Env, escrow_id: u64) -> Result<(), Error> {
+        ensure_not_paused(&env)?;
+
+        let mut escrow = load_escrow_entry_v2(&env, escrow_id)?;
         escrow.depositor.require_auth();
 
-        if escrow.status != EscrowStatus::Created {
+        if escrow_status(&escrow) != EscrowStatus::Created {
             return Err(Error::EscrowAlreadyFunded);
         }
 
@@ -526,11 +717,8 @@ impl VaultixEscrow {
         // Safe to call transfer_from now that basic preconditions hold.
         token_client.transfer_from(&spender, &escrow.depositor, &spender, &escrow.total_amount);
 
-        escrow.status = EscrowStatus::Active;
-        env.storage().persistent().set(&storage_key, &escrow);
-        env.storage()
-            .persistent()
-            .extend_ttl(&storage_key, 100, 2_000_000);
+        set_escrow_status(&mut escrow, EscrowStatus::Active);
+        store_escrow_entry_v2(&env, escrow_id, &escrow);
 
         // Standardized Event
         env.events().publish(
@@ -548,14 +736,9 @@ impl VaultixEscrow {
     /// Collect a signature for releasing funds
     /// The signature can come from either the depositor or a designated third party
     pub fn collect_signature(env: Env, escrow_id: u64, signer: Address) -> Result<(), Error> {
-        let storage_key = get_storage_key(escrow_id);
         ensure_not_paused(&env)?;
 
-        let mut escrow: Escrow = env
-            .storage()
-            .persistent()
-            .get(&storage_key)
-            .ok_or(Error::EscrowNotFound)?;
+        let mut escrow = load_escrow_entry_v2(&env, escrow_id)?;
 
         // Require authentication from the signer
         signer.require_auth();
@@ -570,7 +753,7 @@ impl VaultixEscrow {
         // Add the new signature
         escrow.collected_signatures.push_back(signer.clone());
 
-        env.storage().persistent().set(&storage_key, &escrow);
+        store_escrow_entry_v2(&env, escrow_id, &escrow);
 
         // Emit event
         env.events().publish(
@@ -586,11 +769,8 @@ impl VaultixEscrow {
     }
 
     pub fn get_escrow(env: Env, escrow_id: u64) -> Result<Escrow, Error> {
-        let storage_key = get_storage_key(escrow_id);
-        env.storage()
-            .persistent()
-            .get(&storage_key)
-            .ok_or(Error::EscrowNotFound)
+        let escrow = load_escrow_entry_v2(&env, escrow_id)?;
+        Ok(escrow_entry_to_public(escrow))
     }
 
     pub fn get_state(env: Env, escrow_id: u64) -> Result<EscrowStatus, Error> {
@@ -599,14 +779,9 @@ impl VaultixEscrow {
     }
 
     pub fn release_milestone(env: Env, escrow_id: u64, milestone_index: u32) -> Result<(), Error> {
-        let storage_key = get_storage_key(escrow_id);
         ensure_not_paused(&env)?;
 
-        let mut escrow: Escrow = env
-            .storage()
-            .persistent()
-            .get(&storage_key)
-            .ok_or(Error::EscrowNotFound)?;
+        let mut escrow = load_escrow_entry_v2(&env, escrow_id)?;
 
         // For amounts exceeding the threshold, check multi-signature requirements
         let milestone = escrow
@@ -624,7 +799,7 @@ impl VaultixEscrow {
             escrow.depositor.require_auth();
         }
 
-        if escrow.status != EscrowStatus::Active {
+        if escrow_status(&escrow) != EscrowStatus::Active {
             return Err(Error::EscrowNotActive);
         }
         if milestone_index >= escrow.milestones.len() {
@@ -640,7 +815,11 @@ impl VaultixEscrow {
         }
 
         let (treasury, _) = Self::get_config(env.clone())?;
-        let fee_bps = resolve_fee(&env, escrow_id, &escrow.token_address)?;
+        let fee_bps = resolve_fee_with_escrow_override(
+            &env,
+            &escrow.token_address,
+            escrow_fee_override_opt(&escrow),
+        )?;
         let fee = calculate_fee(milestone.amount, fee_bps)?;
         let payout = milestone
             .amount
@@ -672,10 +851,7 @@ impl VaultixEscrow {
             .checked_add(milestone.amount)
             .ok_or(Error::InvalidMilestoneAmount)?;
 
-        env.storage().persistent().set(&storage_key, &escrow);
-        env.storage()
-            .persistent()
-            .extend_ttl(&storage_key, 100, 2_000_000);
+        store_escrow_entry_v2(&env, escrow_id, &escrow);
 
         // Standardized Event
         env.events().publish(
@@ -697,20 +873,15 @@ impl VaultixEscrow {
         milestone_index: u32,
         buyer: Address,
     ) -> Result<(), Error> {
-        let storage_key = get_storage_key(escrow_id);
         ensure_not_paused(&env)?;
 
-        let mut escrow: Escrow = env
-            .storage()
-            .persistent()
-            .get(&storage_key)
-            .ok_or(Error::EscrowNotFound)?;
+        let mut escrow = load_escrow_entry_v2(&env, escrow_id)?;
         buyer.require_auth();
 
         if escrow.depositor != buyer {
             return Err(Error::UnauthorizedAccess);
         }
-        if escrow.status != EscrowStatus::Active {
+        if escrow_status(&escrow) != EscrowStatus::Active {
             return Err(Error::EscrowNotActive);
         }
         if milestone_index >= escrow.milestones.len() {
@@ -749,7 +920,7 @@ impl VaultixEscrow {
             milestone.amount,
         )?;
 
-        env.storage().persistent().set(&storage_key, &escrow);
+        store_escrow_entry_v2(&env, escrow_id, &escrow);
 
         // Standardized Event
         env.events().publish(
@@ -766,24 +937,21 @@ impl VaultixEscrow {
     }
 
     pub fn raise_dispute(env: Env, escrow_id: u64, caller: Address) -> Result<(), Error> {
-        let storage_key = get_storage_key(escrow_id);
         ensure_not_paused(&env)?;
 
-        let mut escrow: Escrow = env
-            .storage()
-            .persistent()
-            .get(&storage_key)
-            .ok_or(Error::EscrowNotFound)?;
+        let mut escrow = load_escrow_entry_v2(&env, escrow_id)?;
 
         if caller != escrow.depositor && caller != escrow.recipient {
             return Err(Error::UnauthorizedAccess);
         }
         caller.require_auth();
 
-        if escrow.status == EscrowStatus::Disputed {
+        if escrow_status(&escrow) == EscrowStatus::Disputed {
             return Err(Error::AlreadyInDispute);
         }
-        if escrow.status != EscrowStatus::Active && escrow.status != EscrowStatus::Created {
+        if escrow_status(&escrow) != EscrowStatus::Active
+            && escrow_status(&escrow) != EscrowStatus::Created
+        {
             return Err(Error::InvalidEscrowStatus);
         }
 
@@ -797,9 +965,9 @@ impl VaultixEscrow {
         }
 
         escrow.milestones = updated_milestones;
-        escrow.status = EscrowStatus::Disputed;
-        escrow.resolution = Resolution::None;
-        env.storage().persistent().set(&storage_key, &escrow);
+        set_escrow_status(&mut escrow, EscrowStatus::Disputed);
+        set_escrow_resolution(&mut escrow, Resolution::None);
+        store_escrow_entry_v2(&env, escrow_id, &escrow);
 
         // Standardized Event
         env.events().publish(
@@ -823,14 +991,9 @@ impl VaultixEscrow {
         let arbitrator = get_arbitrator(&env)?;
         arbitrator.require_auth();
 
-        let storage_key = get_storage_key(escrow_id);
-        let mut escrow: Escrow = env
-            .storage()
-            .persistent()
-            .get(&storage_key)
-            .ok_or(Error::EscrowNotFound)?;
+        let mut escrow = load_escrow_entry_v2(&env, escrow_id)?;
 
-        if escrow.status != EscrowStatus::Disputed {
+        if escrow_status(&escrow) != EscrowStatus::Disputed {
             return Err(Error::InvalidEscrowStatus);
         }
         if winner != escrow.depositor && winner != escrow.recipient {
@@ -944,9 +1107,9 @@ impl VaultixEscrow {
             return Err(Error::InvalidMilestoneAmount);
         }
 
-        escrow.resolution = resolution;
-        escrow.status = EscrowStatus::Resolved;
-        env.storage().persistent().set(&storage_key, &escrow);
+        set_escrow_resolution(&mut escrow, resolution);
+        set_escrow_status(&mut escrow, EscrowStatus::Resolved);
+        store_escrow_entry_v2(&env, escrow_id, &escrow);
 
         // Standardized Event
         env.events().publish(
@@ -962,14 +1125,9 @@ impl VaultixEscrow {
     }
 
     pub fn cancel_escrow(env: Env, escrow_id: u64) -> Result<(), Error> {
-        let storage_key = get_storage_key(escrow_id);
         ensure_not_paused(&env)?;
 
-        let mut escrow: Escrow = env
-            .storage()
-            .persistent()
-            .get(&storage_key)
-            .ok_or(Error::EscrowNotFound)?;
+        let mut escrow = load_escrow_entry_v2(&env, escrow_id)?;
         escrow.depositor.require_auth();
 
         // Debug: emit start of cancel operation
@@ -979,20 +1137,30 @@ impl VaultixEscrow {
                 Symbol::new(&env, "CancelStart"),
                 escrow_id,
             ),
-            (escrow.total_amount, escrow.total_released, escrow.status),
+            (
+                escrow.total_amount,
+                escrow.total_released,
+                escrow_status(&escrow),
+            ),
         );
 
-        if escrow.status != EscrowStatus::Active && escrow.status != EscrowStatus::Created {
+        if escrow_status(&escrow) != EscrowStatus::Active
+            && escrow_status(&escrow) != EscrowStatus::Created
+        {
             return Err(Error::InvalidEscrowStatus);
         }
         if escrow.total_released > 0 {
             return Err(Error::MilestoneAlreadyReleased);
         }
 
-        if escrow.status == EscrowStatus::Active {
+        if escrow_status(&escrow) == EscrowStatus::Active {
             let token_client = token::Client::new(&env, &escrow.token_address);
             let refund_amount = if let Ok((treasury, _)) = Self::get_config(env.clone()) {
-                let fee_bps = resolve_fee(&env, escrow_id, &escrow.token_address)?;
+                let fee_bps = resolve_fee_with_escrow_override(
+                    &env,
+                    &escrow.token_address,
+                    escrow_fee_override_opt(&escrow),
+                )?;
                 let fee = calculate_fee(escrow.total_amount, fee_bps)?;
                 // Debug: fee resolved
                 env.events().publish(
@@ -1047,11 +1215,8 @@ impl VaultixEscrow {
             }
         }
 
-        escrow.status = EscrowStatus::Cancelled;
-        env.storage().persistent().set(&storage_key, &escrow);
-        env.storage()
-            .persistent()
-            .extend_ttl(&storage_key, 100, 2_000_000);
+        set_escrow_status(&mut escrow, EscrowStatus::Cancelled);
+        store_escrow_entry_v2(&env, escrow_id, &escrow);
 
         // Standardized Event
         env.events().publish(
@@ -1067,28 +1232,20 @@ impl VaultixEscrow {
     }
 
     pub fn complete_escrow(env: Env, escrow_id: u64) -> Result<(), Error> {
-        let storage_key = get_storage_key(escrow_id);
         ensure_not_paused(&env)?;
 
-        let mut escrow: Escrow = env
-            .storage()
-            .persistent()
-            .get(&storage_key)
-            .ok_or(Error::EscrowNotFound)?;
+        let mut escrow = load_escrow_entry_v2(&env, escrow_id)?;
         escrow.depositor.require_auth();
 
-        if escrow.status != EscrowStatus::Active {
+        if escrow_status(&escrow) != EscrowStatus::Active {
             return Err(Error::InvalidEscrowStatus);
         }
         if !verify_all_released(&escrow.milestones) {
             return Err(Error::EscrowNotActive);
         }
 
-        escrow.status = EscrowStatus::Completed;
-        env.storage().persistent().set(&storage_key, &escrow);
-        env.storage()
-            .persistent()
-            .extend_ttl(&storage_key, 100, 2_000_000);
+        set_escrow_status(&mut escrow, EscrowStatus::Completed);
+        store_escrow_entry_v2(&env, escrow_id, &escrow);
 
         // Standardized Event
         env.events().publish(
@@ -1104,14 +1261,7 @@ impl VaultixEscrow {
     }
 
     pub fn refund_expired(env: Env, escrow_id: u64, caller: Address) -> Result<(), Error> {
-        let storage_key = get_storage_key(escrow_id);
-
-        // Load escrow from storage
-        let mut escrow: Escrow = env
-            .storage()
-            .persistent()
-            .get(&storage_key)
-            .ok_or(Error::EscrowNotFound)?;
+        let mut escrow = load_escrow_entry_v2(&env, escrow_id)?;
 
         // Validate deadline has passed
         let current_time = env.ledger().timestamp();
@@ -1120,7 +1270,7 @@ impl VaultixEscrow {
         }
 
         // Validate escrow status is Active
-        if escrow.status != EscrowStatus::Active {
+        if escrow_status(&escrow) != EscrowStatus::Active {
             return Err(Error::InvalidStatusForRefund);
         }
 
@@ -1145,7 +1295,11 @@ impl VaultixEscrow {
         let (treasury, _) = Self::get_config(env.clone())?;
 
         // Resolve fee with precedence: escrow > token > global
-        let fee_bps = resolve_fee(&env, escrow_id, &escrow.token_address)?;
+        let fee_bps = resolve_fee_with_escrow_override(
+            &env,
+            &escrow.token_address,
+            escrow_fee_override_opt(&escrow),
+        )?;
 
         // Calculate platform fee using checked arithmetic
         let platform_fee = calculate_fee(remaining_balance, fee_bps)?;
@@ -1177,12 +1331,9 @@ impl VaultixEscrow {
         }
 
         // Update escrow state
-        escrow.status = EscrowStatus::Expired;
+        set_escrow_status(&mut escrow, EscrowStatus::Expired);
         escrow.total_released = escrow.total_amount;
-        env.storage().persistent().set(&storage_key, &escrow);
-        env.storage()
-            .persistent()
-            .extend_ttl(&storage_key, 100, 2_000_000);
+        store_escrow_entry_v2(&env, escrow_id, &escrow);
 
         // Emit RefundEvent
         env.events().publish(
@@ -1198,8 +1349,12 @@ impl VaultixEscrow {
     }
 }
 
-fn get_storage_key(escrow_id: u64) -> (Symbol, u64) {
+fn get_storage_key_legacy(escrow_id: u64) -> (Symbol, u64) {
     (symbol_short!("escrow"), escrow_id)
+}
+
+fn get_storage_key_v2(escrow_id: u64) -> (Symbol, u64) {
+    (symbol_short!("esc2"), escrow_id)
 }
 
 /// Generates storage key for token-specific fee override
@@ -1214,26 +1369,12 @@ fn get_escrow_fee_key(escrow_id: u64) -> (Symbol, u64) {
     (symbol_short!("escfee"), escrow_id)
 }
 
-/// Resolves the applicable fee for a transaction using the following precedence:
-/// 1. Per-escrow fee override (highest priority)
-/// 2. Per-token fee override
-/// 3. Global default fee (fallback)
-///
-/// # Arguments
-/// * `env` - Soroban environment reference
-/// * `escrow_id` - ID of the escrow transaction
-/// * `token_address` - Token being transferred
-///
-/// # Returns
-/// The fee in basis points to apply for the transaction
-fn resolve_fee(env: &Env, escrow_id: u64, token_address: &Address) -> Result<i128, Error> {
-    // Check escrow-specific override first (highest priority)
-    let escrow_fee_key = get_escrow_fee_key(escrow_id);
-    if let Some(escrow_fee) = env
-        .storage()
-        .persistent()
-        .get::<(Symbol, u64), i128>(&escrow_fee_key)
-    {
+fn resolve_fee_with_escrow_override(
+    env: &Env,
+    token_address: &Address,
+    escrow_fee_override: Option<i128>,
+) -> Result<i128, Error> {
+    if let Some(escrow_fee) = escrow_fee_override {
         return Ok(escrow_fee);
     }
 
@@ -1291,11 +1432,34 @@ fn admin_storage_key() -> Symbol {
     symbol_short!("admin")
 }
 
-fn get_admin(env: &Env) -> Result<Address, Error> {
+fn operator_storage_key() -> Symbol {
+    symbol_short!("oper")
+}
+
+fn arbitrator_storage_key() -> Symbol {
+    symbol_short!("arbi")
+}
+
+fn extend_roles_ttl(env: &Env) {
     env.storage()
         .persistent()
+        .extend_ttl(&admin_storage_key(), 100, 2_000_000);
+    env.storage()
+        .persistent()
+        .extend_ttl(&operator_storage_key(), 100, 2_000_000);
+    env.storage()
+        .persistent()
+        .extend_ttl(&arbitrator_storage_key(), 100, 2_000_000);
+}
+
+fn get_admin(env: &Env) -> Result<Address, Error> {
+    let admin = env
+        .storage()
+        .persistent()
         .get(&admin_storage_key())
-        .ok_or(Error::AdminNotInitialized)
+        .ok_or(Error::AdminNotInitialized)?;
+    extend_roles_ttl(env);
+    Ok(admin)
 }
 
 fn validate_milestones(milestones: &Vec<Milestone>) -> Result<i128, Error> {
@@ -1341,17 +1505,242 @@ fn calculate_fee(amount: i128, fee_bps: i128) -> Result<i128, Error> {
 }
 
 fn get_operator(env: &Env) -> Result<Address, Error> {
-    env.storage()
+    if let Some(op) = env
+        .storage()
         .persistent()
-        .get(&Symbol::new(env, "operator"))
-        .ok_or(Error::OperatorNotInitialized)
+        .get::<Symbol, Address>(&operator_storage_key())
+    {
+        extend_roles_ttl(env);
+        return Ok(op);
+    }
+
+    let legacy_key = Symbol::new(env, "operator");
+    let op: Address = env
+        .storage()
+        .persistent()
+        .get(&legacy_key)
+        .ok_or(Error::OperatorNotInitialized)?;
+    env.storage().persistent().set(&operator_storage_key(), &op);
+    env.storage().persistent().remove(&legacy_key);
+    extend_roles_ttl(env);
+    Ok(op)
 }
 
 fn get_arbitrator(env: &Env) -> Result<Address, Error> {
+    if let Some(a) = env
+        .storage()
+        .persistent()
+        .get::<Symbol, Address>(&arbitrator_storage_key())
+    {
+        extend_roles_ttl(env);
+        return Ok(a);
+    }
+
+    let legacy_key = Symbol::new(env, "arbitrator");
+    let a: Address = env
+        .storage()
+        .persistent()
+        .get(&legacy_key)
+        .ok_or(Error::ArbitratorNotInitialized)?;
     env.storage()
         .persistent()
-        .get(&Symbol::new(env, "arbitrator"))
-        .ok_or(Error::ArbitratorNotInitialized)
+        .set(&arbitrator_storage_key(), &a);
+    env.storage().persistent().remove(&legacy_key);
+    extend_roles_ttl(env);
+    Ok(a)
+}
+
+fn escrow_fee_override_opt(escrow: &EscrowEntryV2) -> Option<i128> {
+    if escrow.fee_override_bps >= 0 {
+        Some(escrow.fee_override_bps)
+    } else {
+        None
+    }
+}
+
+fn escrow_status(escrow: &EscrowEntryV2) -> EscrowStatus {
+    unpack_escrow_status(escrow.packed_state)
+}
+
+fn set_escrow_status(escrow: &mut EscrowEntryV2, status: EscrowStatus) {
+    let resolution = unpack_escrow_resolution(escrow.packed_state);
+    escrow.packed_state = pack_escrow_state(status, resolution);
+}
+
+fn set_escrow_resolution(escrow: &mut EscrowEntryV2, resolution: Resolution) {
+    let status = unpack_escrow_status(escrow.packed_state);
+    escrow.packed_state = pack_escrow_state(status, resolution);
+}
+
+fn pack_escrow_state(status: EscrowStatus, resolution: Resolution) -> u32 {
+    (escrow_status_to_u32(status) & 0x7) | ((resolution_to_u32(resolution) & 0x3) << 3)
+}
+
+fn unpack_escrow_status(packed_state: u32) -> EscrowStatus {
+    u32_to_escrow_status(packed_state & 0x7)
+}
+
+fn unpack_escrow_resolution(packed_state: u32) -> Resolution {
+    u32_to_resolution((packed_state >> 3) & 0x3)
+}
+
+fn escrow_status_to_u32(status: EscrowStatus) -> u32 {
+    match status {
+        EscrowStatus::Created => 0,
+        EscrowStatus::Active => 1,
+        EscrowStatus::Completed => 2,
+        EscrowStatus::Cancelled => 3,
+        EscrowStatus::Disputed => 4,
+        EscrowStatus::Resolved => 5,
+        EscrowStatus::Expired => 6,
+    }
+}
+
+fn u32_to_escrow_status(v: u32) -> EscrowStatus {
+    match v {
+        0 => EscrowStatus::Created,
+        1 => EscrowStatus::Active,
+        2 => EscrowStatus::Completed,
+        3 => EscrowStatus::Cancelled,
+        4 => EscrowStatus::Disputed,
+        5 => EscrowStatus::Resolved,
+        _ => EscrowStatus::Expired,
+    }
+}
+
+fn resolution_to_u32(r: Resolution) -> u32 {
+    match r {
+        Resolution::None => 0,
+        Resolution::Depositor => 1,
+        Resolution::Recipient => 2,
+        Resolution::Split => 3,
+    }
+}
+
+fn u32_to_resolution(v: u32) -> Resolution {
+    match v {
+        0 => Resolution::None,
+        1 => Resolution::Depositor,
+        2 => Resolution::Recipient,
+        _ => Resolution::Split,
+    }
+}
+
+fn store_escrow_entry_v2(env: &Env, escrow_id: u64, escrow: &EscrowEntryV2) {
+    let key = get_storage_key_v2(escrow_id);
+    env.storage().persistent().set(&key, escrow);
+    extend_escrow_ttl(env, &key, escrow);
+}
+
+fn load_escrow_entry_v2(env: &Env, escrow_id: u64) -> Result<EscrowEntryV2, Error> {
+    let v2_key = get_storage_key_v2(escrow_id);
+    if let Some(v2) = env
+        .storage()
+        .persistent()
+        .get::<(Symbol, u64), EscrowEntryV2>(&v2_key)
+    {
+        extend_escrow_ttl(env, &v2_key, &v2);
+        return Ok(v2);
+    }
+
+    let legacy_key = get_storage_key_legacy(escrow_id);
+    let legacy: Escrow = env
+        .storage()
+        .persistent()
+        .get(&legacy_key)
+        .ok_or(Error::EscrowNotFound)?;
+
+    let fee_override_bps = env
+        .storage()
+        .persistent()
+        .get::<(Symbol, u64), i128>(&get_escrow_fee_key(escrow_id))
+        .unwrap_or(-1);
+
+    let v2 = EscrowEntryV2 {
+        depositor: legacy.depositor,
+        recipient: legacy.recipient,
+        token_address: legacy.token_address,
+        total_amount: legacy.total_amount,
+        total_released: legacy.total_released,
+        milestones: legacy.milestones,
+        packed_state: pack_escrow_state(legacy.status, legacy.resolution),
+        deadline: legacy.deadline,
+        threshold_amount: legacy.threshold_amount,
+        required_signatures: legacy.required_signatures,
+        collected_signatures: legacy.collected_signatures,
+        fee_override_bps,
+    };
+
+    env.storage().persistent().remove(&legacy_key);
+    if fee_override_bps >= 0 {
+        env.storage()
+            .persistent()
+            .remove(&get_escrow_fee_key(escrow_id));
+    }
+
+    store_escrow_entry_v2(env, escrow_id, &v2);
+    Ok(v2)
+}
+
+fn escrow_entry_to_public(escrow: EscrowEntryV2) -> Escrow {
+    Escrow {
+        depositor: escrow.depositor,
+        recipient: escrow.recipient,
+        token_address: escrow.token_address,
+        total_amount: escrow.total_amount,
+        total_released: escrow.total_released,
+        milestones: escrow.milestones,
+        status: unpack_escrow_status(escrow.packed_state),
+        deadline: escrow.deadline,
+        resolution: unpack_escrow_resolution(escrow.packed_state),
+        threshold_amount: escrow.threshold_amount,
+        required_signatures: escrow.required_signatures,
+        collected_signatures: escrow.collected_signatures,
+    }
+}
+
+fn extend_escrow_ttl(env: &Env, key: &(Symbol, u64), escrow: &EscrowEntryV2) {
+    let max_ttl = escrow_ttl_max(env, escrow);
+    env.storage().persistent().extend_ttl(key, 100, max_ttl);
+}
+
+fn escrow_ttl_max(env: &Env, escrow: &EscrowEntryV2) -> u32 {
+    let now = env.ledger().timestamp();
+    let active_status = escrow_status(escrow);
+
+    let (seconds, min_ledgers, max_ledgers) = match active_status {
+        EscrowStatus::Created | EscrowStatus::Active | EscrowStatus::Disputed => {
+            let remaining = escrow.deadline.saturating_sub(now);
+            let desired = remaining.saturating_add(86400);
+            (desired, 50_000u32, 1_000_000u32)
+        }
+        EscrowStatus::Completed
+        | EscrowStatus::Cancelled
+        | EscrowStatus::Resolved
+        | EscrowStatus::Expired => (30u64.saturating_mul(86400), 10_000u32, 200_000u32),
+    };
+
+    let mut ledgers = seconds_to_ledgers(seconds);
+    if ledgers < min_ledgers {
+        ledgers = min_ledgers;
+    }
+    if ledgers > max_ledgers {
+        ledgers = max_ledgers;
+    }
+    ledgers
+}
+
+fn seconds_to_ledgers(seconds: u64) -> u32 {
+    let ledger_seconds: u64 = 5;
+    let ledgers = seconds
+        .saturating_add(ledger_seconds.saturating_sub(1))
+        .checked_div(ledger_seconds)
+        .unwrap_or(0);
+    if ledgers > u32::MAX as u64 {
+        u32::MAX
+    } else {
+        ledgers as u32
+    }
 }
 
 #[cfg(test)]

--- a/apps/onchain/src/test.rs
+++ b/apps/onchain/src/test.rs
@@ -210,6 +210,173 @@ fn test_create_and_get_escrow() {
 }
 
 #[test]
+fn test_create_escrows_batch_and_get() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, VaultixEscrow);
+    let client = VaultixEscrowClient::new(&env, &contract_id);
+
+    let depositor = Address::generate(&env);
+    let recipient_1 = Address::generate(&env);
+    let recipient_2 = Address::generate(&env);
+    let token_address = Address::generate(&env);
+
+    let escrow_id_1 = 101u64;
+    let escrow_id_2 = 102u64;
+    let deadline_1 = 1706400000u64;
+    let deadline_2 = 1706403600u64;
+
+    let milestones_1 = vec![
+        &env,
+        Milestone {
+            amount: 3000,
+            status: MilestoneStatus::Pending,
+            description: symbol_short!("A"),
+        },
+        Milestone {
+            amount: 7000,
+            status: MilestoneStatus::Pending,
+            description: symbol_short!("B"),
+        },
+    ];
+    let milestones_2 = vec![
+        &env,
+        Milestone {
+            amount: 10_000,
+            status: MilestoneStatus::Pending,
+            description: symbol_short!("C"),
+        },
+    ];
+
+    let requests = vec![
+        &env,
+        CreateEscrowRequest {
+            escrow_id: escrow_id_1,
+            depositor: depositor.clone(),
+            recipient: recipient_1.clone(),
+            token_address: token_address.clone(),
+            milestones: milestones_1,
+            deadline: deadline_1,
+        },
+        CreateEscrowRequest {
+            escrow_id: escrow_id_2,
+            depositor: depositor.clone(),
+            recipient: recipient_2.clone(),
+            token_address: token_address.clone(),
+            milestones: milestones_2,
+            deadline: deadline_2,
+        },
+    ];
+
+    client.create_escrows_batch(&requests);
+
+    let escrow_1 = client.get_escrow(&escrow_id_1);
+    assert_eq!(escrow_1.depositor, depositor);
+    assert_eq!(escrow_1.recipient, recipient_1);
+    assert_eq!(escrow_1.token_address, token_address);
+    assert_eq!(escrow_1.total_amount, 10_000);
+    assert_eq!(escrow_1.total_released, 0);
+    assert_eq!(escrow_1.status, EscrowStatus::Created);
+    assert_eq!(escrow_1.deadline, deadline_1);
+
+    let escrow_2 = client.get_escrow(&escrow_id_2);
+    assert_eq!(escrow_2.depositor, escrow_1.depositor);
+    assert_eq!(escrow_2.recipient, recipient_2);
+    assert_eq!(escrow_2.token_address, escrow_1.token_address);
+    assert_eq!(escrow_2.total_amount, 10_000);
+    assert_eq!(escrow_2.total_released, 0);
+    assert_eq!(escrow_2.status, EscrowStatus::Created);
+    assert_eq!(escrow_2.deadline, deadline_2);
+
+    let events = env.events().all();
+    let event = events.last().unwrap();
+    assert_eq!(event.0, contract_id);
+
+    let expected_topics: soroban_sdk::Vec<soroban_sdk::Val> = (
+        Symbol::new(&env, "Vaultix"),
+        Symbol::new(&env, "EscrowsCreatedBatch"),
+    )
+        .into_val(&env);
+    assert_eq!(event.1, expected_topics);
+
+    let actual_items: soroban_sdk::Vec<EscrowCreatedBatchItem> = event.2.into_val(&env);
+    let expected_items: soroban_sdk::Vec<EscrowCreatedBatchItem> = vec![
+        &env,
+        EscrowCreatedBatchItem {
+            escrow_id: escrow_id_1,
+            depositor: escrow_1.depositor.clone(),
+            recipient: recipient_1,
+            token_address: escrow_1.token_address.clone(),
+            total_amount: 10_000,
+            deadline: deadline_1,
+        },
+        EscrowCreatedBatchItem {
+            escrow_id: escrow_id_2,
+            depositor: escrow_2.depositor.clone(),
+            recipient: recipient_2,
+            token_address: escrow_2.token_address.clone(),
+            total_amount: 10_000,
+            deadline: deadline_2,
+        },
+    ];
+    assert_eq!(actual_items, expected_items);
+}
+
+#[test]
+fn test_create_escrows_batch_is_atomic() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, VaultixEscrow);
+    let client = VaultixEscrowClient::new(&env, &contract_id);
+
+    let depositor = Address::generate(&env);
+    let recipient_1 = Address::generate(&env);
+    let recipient_2 = Address::generate(&env);
+    let token_address = Address::generate(&env);
+
+    let escrow_id = 201u64;
+    let milestones = vec![
+        &env,
+        Milestone {
+            amount: 10_000,
+            status: MilestoneStatus::Pending,
+            description: symbol_short!("X"),
+        },
+    ];
+
+    let requests = vec![
+        &env,
+        CreateEscrowRequest {
+            escrow_id,
+            depositor: depositor.clone(),
+            recipient: recipient_1,
+            token_address: token_address.clone(),
+            milestones: milestones.clone(),
+            deadline: 1706400000u64,
+        },
+        CreateEscrowRequest {
+            escrow_id,
+            depositor,
+            recipient: recipient_2,
+            token_address,
+            milestones,
+            deadline: 1706403600u64,
+        },
+    ];
+
+    let result = client.try_create_escrows_batch(&requests);
+    assert_eq!(result, Err(Ok(Error::EscrowAlreadyExists)));
+
+    let get_result = client.try_get_escrow(&escrow_id);
+    assert_eq!(get_result, Err(Ok(Error::EscrowNotFound)));
+
+    let events = env.events().all();
+    assert_eq!(events.len(), 0);
+}
+
+#[test]
 fn test_deposit_funds() {
     let env = Env::default();
     env.mock_all_auths();

--- a/apps/onchain/test_snapshots/fee_tests/test_cancel_escrow_uses_token_fee_override.1.json
+++ b/apps/onchain/test_snapshots/fee_tests/test_cancel_escrow_uses_token_fee_override.1.json
@@ -318,7 +318,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "escrow"
+                  "symbol": "esc2"
                 },
                 {
                   "u64": 1
@@ -338,7 +338,7 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "escrow"
+                      "symbol": "esc2"
                     },
                     {
                       "u64": 1
@@ -370,6 +370,17 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_override_bps"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": -1,
+                          "lo": 18446744073709551615
+                        }
                       }
                     },
                     {
@@ -418,6 +429,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "packed_state"
+                      },
+                      "val": {
+                        "u32": 3
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "recipient"
                       },
                       "val": {
@@ -430,30 +449,6 @@
                       },
                       "val": {
                         "u32": 1
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "resolution"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "None"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Cancelled"
-                          }
-                        ]
                       }
                     },
                     {

--- a/apps/onchain/test_snapshots/fee_tests/test_fee_precedence_escrow_over_token_and_global.1.json
+++ b/apps/onchain/test_snapshots/fee_tests/test_fee_precedence_escrow_over_token_and_global.1.json
@@ -377,7 +377,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "escfee"
+                  "symbol": "esc2"
                 },
                 {
                   "u64": 1
@@ -397,55 +397,7 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "escfee"
-                    },
-                    {
-                      "u64": 1
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 250
-                  }
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          4095
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "escrow"
-                },
-                {
-                  "u64": 1
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "escrow"
+                      "symbol": "esc2"
                     },
                     {
                       "u64": 1
@@ -477,6 +429,17 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_override_bps"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 250
+                        }
                       }
                     },
                     {
@@ -525,6 +488,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "packed_state"
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "recipient"
                       },
                       "val": {
@@ -537,30 +508,6 @@
                       },
                       "val": {
                         "u32": 1
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "resolution"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "None"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Active"
-                          }
-                        ]
                       }
                     },
                     {

--- a/apps/onchain/test_snapshots/fee_tests/test_refund_expired_uses_escrow_fee_override.1.json
+++ b/apps/onchain/test_snapshots/fee_tests/test_refund_expired_uses_escrow_fee_override.1.json
@@ -321,7 +321,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "escfee"
+                  "symbol": "esc2"
                 },
                 {
                   "u64": 1
@@ -341,55 +341,7 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "escfee"
-                    },
-                    {
-                      "u64": 1
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 500
-                  }
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          4095
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "escrow"
-                },
-                {
-                  "u64": 1
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "escrow"
+                      "symbol": "esc2"
                     },
                     {
                       "u64": 1
@@ -421,6 +373,17 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_override_bps"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 500
+                        }
                       }
                     },
                     {
@@ -469,6 +432,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "packed_state"
+                      },
+                      "val": {
+                        "u32": 6
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "recipient"
                       },
                       "val": {
@@ -481,30 +452,6 @@
                       },
                       "val": {
                         "u32": 1
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "resolution"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "None"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Expired"
-                          }
-                        ]
                       }
                     },
                     {

--- a/apps/onchain/test_snapshots/fee_tests/test_release_milestone_uses_escrow_fee_override.1.json
+++ b/apps/onchain/test_snapshots/fee_tests/test_release_milestone_uses_escrow_fee_override.1.json
@@ -408,7 +408,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "escfee"
+                  "symbol": "esc2"
                 },
                 {
                   "u64": 1
@@ -428,55 +428,7 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "escfee"
-                    },
-                    {
-                      "u64": 1
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 300
-                  }
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          4095
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "escrow"
-                },
-                {
-                  "u64": 1
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "escrow"
+                      "symbol": "esc2"
                     },
                     {
                       "u64": 1
@@ -508,6 +460,17 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_override_bps"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 300
+                        }
                       }
                     },
                     {
@@ -556,6 +519,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "packed_state"
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "recipient"
                       },
                       "val": {
@@ -568,30 +539,6 @@
                       },
                       "val": {
                         "u32": 1
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "resolution"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "None"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Active"
-                          }
-                        ]
                       }
                     },
                     {

--- a/apps/onchain/test_snapshots/fee_tests/test_release_milestone_uses_global_fee_by_default.1.json
+++ b/apps/onchain/test_snapshots/fee_tests/test_release_milestone_uses_global_fee_by_default.1.json
@@ -358,7 +358,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "escrow"
+                  "symbol": "esc2"
                 },
                 {
                   "u64": 1
@@ -378,7 +378,7 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "escrow"
+                      "symbol": "esc2"
                     },
                     {
                       "u64": 1
@@ -410,6 +410,17 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_override_bps"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": -1,
+                          "lo": 18446744073709551615
+                        }
                       }
                     },
                     {
@@ -458,6 +469,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "packed_state"
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "recipient"
                       },
                       "val": {
@@ -470,30 +489,6 @@
                       },
                       "val": {
                         "u32": 1
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "resolution"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "None"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Active"
-                          }
-                        ]
                       }
                     },
                     {

--- a/apps/onchain/test_snapshots/fee_tests/test_release_milestone_uses_token_fee_override.1.json
+++ b/apps/onchain/test_snapshots/fee_tests/test_release_milestone_uses_token_fee_override.1.json
@@ -383,7 +383,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "escrow"
+                  "symbol": "esc2"
                 },
                 {
                   "u64": 1
@@ -403,7 +403,7 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "escrow"
+                      "symbol": "esc2"
                     },
                     {
                       "u64": 1
@@ -435,6 +435,17 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_override_bps"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": -1,
+                          "lo": 18446744073709551615
+                        }
                       }
                     },
                     {
@@ -483,6 +494,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "packed_state"
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "recipient"
                       },
                       "val": {
@@ -495,30 +514,6 @@
                       },
                       "val": {
                         "u32": 1
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "resolution"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "None"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Active"
-                          }
-                        ]
                       }
                     },
                     {

--- a/apps/onchain/test_snapshots/fee_tests/test_zero_fee_valid.1.json
+++ b/apps/onchain/test_snapshots/fee_tests/test_zero_fee_valid.1.json
@@ -321,7 +321,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "escrow"
+                  "symbol": "esc2"
                 },
                 {
                   "u64": 1
@@ -341,7 +341,7 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "escrow"
+                      "symbol": "esc2"
                     },
                     {
                       "u64": 1
@@ -373,6 +373,17 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_override_bps"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": -1,
+                          "lo": 18446744073709551615
+                        }
                       }
                     },
                     {
@@ -421,6 +432,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "packed_state"
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "recipient"
                       },
                       "val": {
@@ -433,30 +452,6 @@
                       },
                       "val": {
                         "u32": 1
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "resolution"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "None"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Active"
-                          }
-                        ]
                       }
                     },
                     {

--- a/apps/onchain/test_snapshots/test/test_admin_resolves_dispute_to_depositor.1.json
+++ b/apps/onchain/test_snapshots/test/test_admin_resolves_dispute_to_depositor.1.json
@@ -385,7 +385,7 @@
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": {
-              "symbol": "arbitrator"
+              "symbol": "arbi"
             },
             "durability": "persistent"
           }
@@ -398,7 +398,7 @@
                 "ext": "v0",
                 "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
                 "key": {
-                  "symbol": "arbitrator"
+                  "symbol": "arbi"
                 },
                 "durability": "persistent",
                 "val": {
@@ -416,7 +416,7 @@
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": {
-              "symbol": "operator"
+              "symbol": "oper"
             },
             "durability": "persistent"
           }
@@ -429,7 +429,7 @@
                 "ext": "v0",
                 "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
                 "key": {
-                  "symbol": "operator"
+                  "symbol": "oper"
                 },
                 "durability": "persistent",
                 "val": {
@@ -449,7 +449,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "escrow"
+                  "symbol": "esc2"
                 },
                 {
                   "u64": 11
@@ -469,7 +469,7 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "escrow"
+                      "symbol": "esc2"
                     },
                     {
                       "u64": 11
@@ -501,6 +501,17 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_override_bps"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": -1,
+                          "lo": 18446744073709551615
+                        }
                       }
                     },
                     {
@@ -584,6 +595,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "packed_state"
+                      },
+                      "val": {
+                        "u32": 13
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "recipient"
                       },
                       "val": {
@@ -596,30 +615,6 @@
                       },
                       "val": {
                         "u32": 1
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "resolution"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Depositor"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Resolved"
-                          }
-                        ]
                       }
                     },
                     {

--- a/apps/onchain/test_snapshots/test/test_admin_resolves_dispute_to_recipient.1.json
+++ b/apps/onchain/test_snapshots/test/test_admin_resolves_dispute_to_recipient.1.json
@@ -385,7 +385,7 @@
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": {
-              "symbol": "arbitrator"
+              "symbol": "arbi"
             },
             "durability": "persistent"
           }
@@ -398,7 +398,7 @@
                 "ext": "v0",
                 "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
                 "key": {
-                  "symbol": "arbitrator"
+                  "symbol": "arbi"
                 },
                 "durability": "persistent",
                 "val": {
@@ -416,7 +416,7 @@
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": {
-              "symbol": "operator"
+              "symbol": "oper"
             },
             "durability": "persistent"
           }
@@ -429,7 +429,7 @@
                 "ext": "v0",
                 "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
                 "key": {
-                  "symbol": "operator"
+                  "symbol": "oper"
                 },
                 "durability": "persistent",
                 "val": {
@@ -449,7 +449,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "escrow"
+                  "symbol": "esc2"
                 },
                 {
                   "u64": 10
@@ -469,7 +469,7 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "escrow"
+                      "symbol": "esc2"
                     },
                     {
                       "u64": 10
@@ -501,6 +501,17 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_override_bps"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": -1,
+                          "lo": 18446744073709551615
+                        }
                       }
                     },
                     {
@@ -584,6 +595,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "packed_state"
+                      },
+                      "val": {
+                        "u32": 21
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "recipient"
                       },
                       "val": {
@@ -596,30 +615,6 @@
                       },
                       "val": {
                         "u32": 1
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "resolution"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Recipient"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Resolved"
-                          }
-                        ]
                       }
                     },
                     {

--- a/apps/onchain/test_snapshots/test/test_cancel_active_escrow_retains_fee.1.json
+++ b/apps/onchain/test_snapshots/test/test_cancel_active_escrow_retains_fee.1.json
@@ -297,7 +297,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "escrow"
+                  "symbol": "esc2"
                 },
                 {
                   "u64": 20
@@ -317,7 +317,7 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "escrow"
+                      "symbol": "esc2"
                     },
                     {
                       "u64": 20
@@ -349,6 +349,17 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_override_bps"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": -1,
+                          "lo": 18446744073709551615
+                        }
                       }
                     },
                     {
@@ -397,6 +408,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "packed_state"
+                      },
+                      "val": {
+                        "u32": 3
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "recipient"
                       },
                       "val": {
@@ -409,30 +428,6 @@
                       },
                       "val": {
                         "u32": 1
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "resolution"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "None"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Cancelled"
-                          }
-                        ]
                       }
                     },
                     {

--- a/apps/onchain/test_snapshots/test/test_cancel_escrow_uses_token_fee_override.1.json
+++ b/apps/onchain/test_snapshots/test/test_cancel_escrow_uses_token_fee_override.1.json
@@ -349,7 +349,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "escrow"
+                  "symbol": "esc2"
                 },
                 {
                   "u64": 1
@@ -369,7 +369,7 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "escrow"
+                      "symbol": "esc2"
                     },
                     {
                       "u64": 1
@@ -401,6 +401,17 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_override_bps"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": -1,
+                          "lo": 18446744073709551615
+                        }
                       }
                     },
                     {
@@ -449,6 +460,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "packed_state"
+                      },
+                      "val": {
+                        "u32": 3
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "recipient"
                       },
                       "val": {
@@ -461,30 +480,6 @@
                       },
                       "val": {
                         "u32": 1
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "resolution"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "None"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Cancelled"
-                          }
-                        ]
                       }
                     },
                     {

--- a/apps/onchain/test_snapshots/test/test_cancel_escrow_with_refund.1.json
+++ b/apps/onchain/test_snapshots/test/test_cancel_escrow_with_refund.1.json
@@ -271,7 +271,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "escrow"
+                  "symbol": "esc2"
                 },
                 {
                   "u64": 5
@@ -291,7 +291,7 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "escrow"
+                      "symbol": "esc2"
                     },
                     {
                       "u64": 5
@@ -323,6 +323,17 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_override_bps"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": -1,
+                          "lo": 18446744073709551615
+                        }
                       }
                     },
                     {
@@ -371,6 +382,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "packed_state"
+                      },
+                      "val": {
+                        "u32": 3
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "recipient"
                       },
                       "val": {
@@ -383,30 +402,6 @@
                       },
                       "val": {
                         "u32": 1
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "resolution"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "None"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Cancelled"
-                          }
-                        ]
                       }
                     },
                     {

--- a/apps/onchain/test_snapshots/test/test_cancel_unfunded_escrow.1.json
+++ b/apps/onchain/test_snapshots/test/test_cancel_unfunded_escrow.1.json
@@ -192,7 +192,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "escrow"
+                  "symbol": "esc2"
                 },
                 {
                   "u64": 6
@@ -212,7 +212,7 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "escrow"
+                      "symbol": "esc2"
                     },
                     {
                       "u64": 6
@@ -244,6 +244,17 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_override_bps"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": -1,
+                          "lo": 18446744073709551615
+                        }
                       }
                     },
                     {
@@ -292,6 +303,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "packed_state"
+                      },
+                      "val": {
+                        "u32": 3
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "recipient"
                       },
                       "val": {
@@ -304,30 +323,6 @@
                       },
                       "val": {
                         "u32": 1
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "resolution"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "None"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Cancelled"
-                          }
-                        ]
                       }
                     },
                     {

--- a/apps/onchain/test_snapshots/test/test_collect_signature.1.json
+++ b/apps/onchain/test_snapshots/test/test_collect_signature.1.json
@@ -296,7 +296,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "escrow"
+                  "symbol": "esc2"
                 },
                 {
                   "u64": 101
@@ -316,7 +316,7 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "escrow"
+                      "symbol": "esc2"
                     },
                     {
                       "u64": 101
@@ -355,6 +355,17 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_override_bps"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": -1,
+                          "lo": 18446744073709551615
+                        }
                       }
                     },
                     {
@@ -403,6 +414,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "packed_state"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "recipient"
                       },
                       "val": {
@@ -415,30 +434,6 @@
                       },
                       "val": {
                         "u32": 2
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "resolution"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "None"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Created"
-                          }
-                        ]
                       }
                     },
                     {

--- a/apps/onchain/test_snapshots/test/test_complete_escrow_with_all_releases.1.json
+++ b/apps/onchain/test_snapshots/test/test_complete_escrow_with_all_releases.1.json
@@ -354,7 +354,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "escrow"
+                  "symbol": "esc2"
                 },
                 {
                   "u64": 4
@@ -374,7 +374,7 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "escrow"
+                      "symbol": "esc2"
                     },
                     {
                       "u64": 4
@@ -406,6 +406,17 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_override_bps"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": -1,
+                          "lo": 18446744073709551615
+                        }
                       }
                     },
                     {
@@ -489,6 +500,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "packed_state"
+                      },
+                      "val": {
+                        "u32": 2
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "recipient"
                       },
                       "val": {
@@ -501,30 +520,6 @@
                       },
                       "val": {
                         "u32": 1
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "resolution"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "None"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Completed"
-                          }
-                        ]
                       }
                     },
                     {

--- a/apps/onchain/test_snapshots/test/test_configure_multisig_threshold.1.json
+++ b/apps/onchain/test_snapshots/test/test_configure_multisig_threshold.1.json
@@ -251,7 +251,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "escrow"
+                  "symbol": "esc2"
                 },
                 {
                   "u64": 100
@@ -271,7 +271,7 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "escrow"
+                      "symbol": "esc2"
                     },
                     {
                       "u64": 100
@@ -303,6 +303,17 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_override_bps"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": -1,
+                          "lo": 18446744073709551615
+                        }
                       }
                     },
                     {
@@ -351,6 +362,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "packed_state"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "recipient"
                       },
                       "val": {
@@ -363,30 +382,6 @@
                       },
                       "val": {
                         "u32": 2
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "resolution"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "None"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Created"
-                          }
-                        ]
                       }
                     },
                     {

--- a/apps/onchain/test_snapshots/test/test_create_and_get_escrow.1.json
+++ b/apps/onchain/test_snapshots/test/test_create_and_get_escrow.1.json
@@ -271,7 +271,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "escrow"
+                  "symbol": "esc2"
                 },
                 {
                   "u64": 1
@@ -291,7 +291,7 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "escrow"
+                      "symbol": "esc2"
                     },
                     {
                       "u64": 1
@@ -323,6 +323,17 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_override_bps"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": -1,
+                          "lo": 18446744073709551615
+                        }
                       }
                     },
                     {
@@ -441,6 +452,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "packed_state"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "recipient"
                       },
                       "val": {
@@ -453,30 +472,6 @@
                       },
                       "val": {
                         "u32": 1
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "resolution"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "None"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Created"
-                          }
-                        ]
                       }
                     },
                     {

--- a/apps/onchain/test_snapshots/test/test_create_escrow_fails_when_paused.1.json
+++ b/apps/onchain/test_snapshots/test/test_create_escrow_fails_when_paused.1.json
@@ -221,7 +221,7 @@
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": {
-              "symbol": "arbitrator"
+              "symbol": "arbi"
             },
             "durability": "persistent"
           }
@@ -234,7 +234,7 @@
                 "ext": "v0",
                 "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
                 "key": {
-                  "symbol": "arbitrator"
+                  "symbol": "arbi"
                 },
                 "durability": "persistent",
                 "val": {
@@ -252,7 +252,7 @@
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": {
-              "symbol": "operator"
+              "symbol": "oper"
             },
             "durability": "persistent"
           }
@@ -265,7 +265,7 @@
                 "ext": "v0",
                 "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
                 "key": {
-                  "symbol": "operator"
+                  "symbol": "oper"
                 },
                 "durability": "persistent",
                 "val": {

--- a/apps/onchain/test_snapshots/test/test_create_escrows_batch_and_get.1.json
+++ b/apps/onchain/test_snapshots/test/test_create_escrows_batch_and_get.1.json
@@ -1,0 +1,1582 @@
+{
+  "generators": {
+    "address": 5,
+    "nonce": 0
+  },
+  "auth": [
+    [
+      [
+        "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+        {
+          "function": {
+            "contract_fn": {
+              "contract_address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+              "function_name": "create_escrows_batch",
+              "args": [
+                {
+                  "vec": [
+                    {
+                      "map": [
+                        {
+                          "key": {
+                            "symbol": "deadline"
+                          },
+                          "val": {
+                            "u64": 1706400000
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "depositor"
+                          },
+                          "val": {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "escrow_id"
+                          },
+                          "val": {
+                            "u64": 101
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "milestones"
+                          },
+                          "val": {
+                            "vec": [
+                              {
+                                "map": [
+                                  {
+                                    "key": {
+                                      "symbol": "amount"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 3000
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "description"
+                                    },
+                                    "val": {
+                                      "symbol": "A"
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "status"
+                                    },
+                                    "val": {
+                                      "vec": [
+                                        {
+                                          "symbol": "Pending"
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              },
+                              {
+                                "map": [
+                                  {
+                                    "key": {
+                                      "symbol": "amount"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 7000
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "description"
+                                    },
+                                    "val": {
+                                      "symbol": "B"
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "status"
+                                    },
+                                    "val": {
+                                      "vec": [
+                                        {
+                                          "symbol": "Pending"
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "recipient"
+                          },
+                          "val": {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "token_address"
+                          },
+                          "val": {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                          }
+                        }
+                      ]
+                    },
+                    {
+                      "map": [
+                        {
+                          "key": {
+                            "symbol": "deadline"
+                          },
+                          "val": {
+                            "u64": 1706403600
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "depositor"
+                          },
+                          "val": {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "escrow_id"
+                          },
+                          "val": {
+                            "u64": 102
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "milestones"
+                          },
+                          "val": {
+                            "vec": [
+                              {
+                                "map": [
+                                  {
+                                    "key": {
+                                      "symbol": "amount"
+                                    },
+                                    "val": {
+                                      "i128": {
+                                        "hi": 0,
+                                        "lo": 10000
+                                      }
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "description"
+                                    },
+                                    "val": {
+                                      "symbol": "C"
+                                    }
+                                  },
+                                  {
+                                    "key": {
+                                      "symbol": "status"
+                                    },
+                                    "val": {
+                                      "vec": [
+                                        {
+                                          "symbol": "Pending"
+                                        }
+                                      ]
+                                    }
+                                  }
+                                ]
+                              }
+                            ]
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "recipient"
+                          },
+                          "val": {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                          }
+                        },
+                        {
+                          "key": {
+                            "symbol": "token_address"
+                          },
+                          "val": {
+                            "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                          }
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "sub_invocations": []
+        }
+      ]
+    ],
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 20,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "esc2"
+                },
+                {
+                  "u64": 101
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "esc2"
+                    },
+                    {
+                      "u64": 101
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "collected_signatures"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "deadline"
+                      },
+                      "val": {
+                        "u64": 1706400000
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "depositor"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_override_bps"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": -1,
+                          "lo": 18446744073709551615
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "milestones"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "map": [
+                              {
+                                "key": {
+                                  "symbol": "amount"
+                                },
+                                "val": {
+                                  "i128": {
+                                    "hi": 0,
+                                    "lo": 3000
+                                  }
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "description"
+                                },
+                                "val": {
+                                  "symbol": "A"
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "status"
+                                },
+                                "val": {
+                                  "vec": [
+                                    {
+                                      "symbol": "Pending"
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "map": [
+                              {
+                                "key": {
+                                  "symbol": "amount"
+                                },
+                                "val": {
+                                  "i128": {
+                                    "hi": 0,
+                                    "lo": 7000
+                                  }
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "description"
+                                },
+                                "val": {
+                                  "symbol": "B"
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "status"
+                                },
+                                "val": {
+                                  "vec": [
+                                    {
+                                      "symbol": "Pending"
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "packed_state"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "recipient"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "required_signatures"
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "threshold_amount"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 10000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "token_address"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_amount"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 10000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_released"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 0
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": {
+              "vec": [
+                {
+                  "symbol": "esc2"
+                },
+                {
+                  "u64": 102
+                }
+              ]
+            },
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": {
+                  "vec": [
+                    {
+                      "symbol": "esc2"
+                    },
+                    {
+                      "u64": 102
+                    }
+                  ]
+                },
+                "durability": "persistent",
+                "val": {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "collected_signatures"
+                      },
+                      "val": {
+                        "vec": []
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "deadline"
+                      },
+                      "val": {
+                        "u64": 1706403600
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "depositor"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_override_bps"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": -1,
+                          "lo": 18446744073709551615
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "milestones"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "map": [
+                              {
+                                "key": {
+                                  "symbol": "amount"
+                                },
+                                "val": {
+                                  "i128": {
+                                    "hi": 0,
+                                    "lo": 10000
+                                  }
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "description"
+                                },
+                                "val": {
+                                  "symbol": "C"
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "status"
+                                },
+                                "val": {
+                                  "vec": [
+                                    {
+                                      "symbol": "Pending"
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "packed_state"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "recipient"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "required_signatures"
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "threshold_amount"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 10000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "token_address"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_amount"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 10000
+                        }
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_released"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 0
+                        }
+                      }
+                    }
+                  ]
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+            "key": {
+              "ledger_key_nonce": {
+                "nonce": 801925984706572462
+              }
+            },
+            "durability": "temporary"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4",
+                "key": {
+                  "ledger_key_nonce": {
+                    "nonce": 801925984706572462
+                  }
+                },
+                "durability": "temporary",
+                "val": "void"
+              }
+            },
+            "ext": "v0"
+          },
+          15
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "create_escrows_batch"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "deadline"
+                      },
+                      "val": {
+                        "u64": 1706400000
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "depositor"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "escrow_id"
+                      },
+                      "val": {
+                        "u64": 101
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "milestones"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "map": [
+                              {
+                                "key": {
+                                  "symbol": "amount"
+                                },
+                                "val": {
+                                  "i128": {
+                                    "hi": 0,
+                                    "lo": 3000
+                                  }
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "description"
+                                },
+                                "val": {
+                                  "symbol": "A"
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "status"
+                                },
+                                "val": {
+                                  "vec": [
+                                    {
+                                      "symbol": "Pending"
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          },
+                          {
+                            "map": [
+                              {
+                                "key": {
+                                  "symbol": "amount"
+                                },
+                                "val": {
+                                  "i128": {
+                                    "hi": 0,
+                                    "lo": 7000
+                                  }
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "description"
+                                },
+                                "val": {
+                                  "symbol": "B"
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "status"
+                                },
+                                "val": {
+                                  "vec": [
+                                    {
+                                      "symbol": "Pending"
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "recipient"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "token_address"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "deadline"
+                      },
+                      "val": {
+                        "u64": 1706403600
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "depositor"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "escrow_id"
+                      },
+                      "val": {
+                        "u64": 102
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "milestones"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "map": [
+                              {
+                                "key": {
+                                  "symbol": "amount"
+                                },
+                                "val": {
+                                  "i128": {
+                                    "hi": 0,
+                                    "lo": 10000
+                                  }
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "description"
+                                },
+                                "val": {
+                                  "symbol": "C"
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "status"
+                                },
+                                "val": {
+                                  "vec": [
+                                    {
+                                      "symbol": "Pending"
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "recipient"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "token_address"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "Vaultix"
+              },
+              {
+                "symbol": "EscrowsCreatedBatch"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "deadline"
+                      },
+                      "val": {
+                        "u64": 1706400000
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "depositor"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "escrow_id"
+                      },
+                      "val": {
+                        "u64": 101
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "recipient"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "token_address"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_amount"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 10000
+                        }
+                      }
+                    }
+                  ]
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "deadline"
+                      },
+                      "val": {
+                        "u64": 1706403600
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "depositor"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "escrow_id"
+                      },
+                      "val": {
+                        "u64": 102
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "recipient"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "token_address"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "total_amount"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 10000
+                        }
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "create_escrows_batch"
+              }
+            ],
+            "data": "void"
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "get_escrow"
+              }
+            ],
+            "data": {
+              "u64": 101
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "get_escrow"
+              }
+            ],
+            "data": {
+              "map": [
+                {
+                  "key": {
+                    "symbol": "collected_signatures"
+                  },
+                  "val": {
+                    "vec": []
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "deadline"
+                  },
+                  "val": {
+                    "u64": 1706400000
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "depositor"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "milestones"
+                  },
+                  "val": {
+                    "vec": [
+                      {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "amount"
+                            },
+                            "val": {
+                              "i128": {
+                                "hi": 0,
+                                "lo": 3000
+                              }
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "description"
+                            },
+                            "val": {
+                              "symbol": "A"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "status"
+                            },
+                            "val": {
+                              "vec": [
+                                {
+                                  "symbol": "Pending"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      },
+                      {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "amount"
+                            },
+                            "val": {
+                              "i128": {
+                                "hi": 0,
+                                "lo": 7000
+                              }
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "description"
+                            },
+                            "val": {
+                              "symbol": "B"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "status"
+                            },
+                            "val": {
+                              "vec": [
+                                {
+                                  "symbol": "Pending"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "recipient"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "required_signatures"
+                  },
+                  "val": {
+                    "u32": 1
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "resolution"
+                  },
+                  "val": {
+                    "vec": [
+                      {
+                        "symbol": "None"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "status"
+                  },
+                  "val": {
+                    "vec": [
+                      {
+                        "symbol": "Created"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "threshold_amount"
+                  },
+                  "val": {
+                    "i128": {
+                      "hi": 0,
+                      "lo": 10000
+                    }
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "token_address"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "total_amount"
+                  },
+                  "val": {
+                    "i128": {
+                      "hi": 0,
+                      "lo": 10000
+                    }
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "total_released"
+                  },
+                  "val": {
+                    "i128": {
+                      "hi": 0,
+                      "lo": 0
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "get_escrow"
+              }
+            ],
+            "data": {
+              "u64": 102
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "get_escrow"
+              }
+            ],
+            "data": {
+              "map": [
+                {
+                  "key": {
+                    "symbol": "collected_signatures"
+                  },
+                  "val": {
+                    "vec": []
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "deadline"
+                  },
+                  "val": {
+                    "u64": 1706403600
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "depositor"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "milestones"
+                  },
+                  "val": {
+                    "vec": [
+                      {
+                        "map": [
+                          {
+                            "key": {
+                              "symbol": "amount"
+                            },
+                            "val": {
+                              "i128": {
+                                "hi": 0,
+                                "lo": 10000
+                              }
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "description"
+                            },
+                            "val": {
+                              "symbol": "C"
+                            }
+                          },
+                          {
+                            "key": {
+                              "symbol": "status"
+                            },
+                            "val": {
+                              "vec": [
+                                {
+                                  "symbol": "Pending"
+                                }
+                              ]
+                            }
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "recipient"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "required_signatures"
+                  },
+                  "val": {
+                    "u32": 1
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "resolution"
+                  },
+                  "val": {
+                    "vec": [
+                      {
+                        "symbol": "None"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "status"
+                  },
+                  "val": {
+                    "vec": [
+                      {
+                        "symbol": "Created"
+                      }
+                    ]
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "threshold_amount"
+                  },
+                  "val": {
+                    "i128": {
+                      "hi": 0,
+                      "lo": 10000
+                    }
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "token_address"
+                  },
+                  "val": {
+                    "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "total_amount"
+                  },
+                  "val": {
+                    "i128": {
+                      "hi": 0,
+                      "lo": 10000
+                    }
+                  }
+                },
+                {
+                  "key": {
+                    "symbol": "total_released"
+                  },
+                  "val": {
+                    "i128": {
+                      "hi": 0,
+                      "lo": 0
+                    }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/apps/onchain/test_snapshots/test/test_create_escrows_batch_is_atomic.1.json
+++ b/apps/onchain/test_snapshots/test/test_create_escrows_batch_is_atomic.1.json
@@ -1,0 +1,661 @@
+{
+  "generators": {
+    "address": 5,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 20,
+    "sequence_number": 0,
+    "timestamp": 0,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "create_escrows_batch"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "deadline"
+                      },
+                      "val": {
+                        "u64": 1706400000
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "depositor"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "escrow_id"
+                      },
+                      "val": {
+                        "u64": 201
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "milestones"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "map": [
+                              {
+                                "key": {
+                                  "symbol": "amount"
+                                },
+                                "val": {
+                                  "i128": {
+                                    "hi": 0,
+                                    "lo": 10000
+                                  }
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "description"
+                                },
+                                "val": {
+                                  "symbol": "X"
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "status"
+                                },
+                                "val": {
+                                  "vec": [
+                                    {
+                                      "symbol": "Pending"
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "recipient"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "token_address"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    }
+                  ]
+                },
+                {
+                  "map": [
+                    {
+                      "key": {
+                        "symbol": "deadline"
+                      },
+                      "val": {
+                        "u64": 1706403600
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "depositor"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "escrow_id"
+                      },
+                      "val": {
+                        "u64": 201
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "milestones"
+                      },
+                      "val": {
+                        "vec": [
+                          {
+                            "map": [
+                              {
+                                "key": {
+                                  "symbol": "amount"
+                                },
+                                "val": {
+                                  "i128": {
+                                    "hi": 0,
+                                    "lo": 10000
+                                  }
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "description"
+                                },
+                                "val": {
+                                  "symbol": "X"
+                                }
+                              },
+                              {
+                                "key": {
+                                  "symbol": "status"
+                                },
+                                "val": {
+                                  "vec": [
+                                    {
+                                      "symbol": "Pending"
+                                    }
+                                  ]
+                                }
+                              }
+                            ]
+                          }
+                        ]
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "recipient"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "token_address"
+                      },
+                      "val": {
+                        "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "create_escrows_batch"
+              }
+            ],
+            "data": {
+              "error": {
+                "contract": 2
+              }
+            }
+          }
+        }
+      },
+      "failed_call": true
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "error"
+              },
+              {
+                "error": {
+                  "contract": 2
+                }
+              }
+            ],
+            "data": {
+              "string": "escalating Ok(ScErrorType::Contract) frame-exit to Err"
+            }
+          }
+        }
+      },
+      "failed_call": true
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "error"
+              },
+              {
+                "error": {
+                  "contract": 2
+                }
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "string": "contract try_call failed"
+                },
+                {
+                  "symbol": "create_escrows_batch"
+                },
+                {
+                  "vec": [
+                    {
+                      "vec": [
+                        {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "deadline"
+                              },
+                              "val": {
+                                "u64": 1706400000
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "depositor"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "escrow_id"
+                              },
+                              "val": {
+                                "u64": 201
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "milestones"
+                              },
+                              "val": {
+                                "vec": [
+                                  {
+                                    "map": [
+                                      {
+                                        "key": {
+                                          "symbol": "amount"
+                                        },
+                                        "val": {
+                                          "i128": {
+                                            "hi": 0,
+                                            "lo": 10000
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "key": {
+                                          "symbol": "description"
+                                        },
+                                        "val": {
+                                          "symbol": "X"
+                                        }
+                                      },
+                                      {
+                                        "key": {
+                                          "symbol": "status"
+                                        },
+                                        "val": {
+                                          "vec": [
+                                            {
+                                              "symbol": "Pending"
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "recipient"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "token_address"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                              }
+                            }
+                          ]
+                        },
+                        {
+                          "map": [
+                            {
+                              "key": {
+                                "symbol": "deadline"
+                              },
+                              "val": {
+                                "u64": 1706403600
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "depositor"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "escrow_id"
+                              },
+                              "val": {
+                                "u64": 201
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "milestones"
+                              },
+                              "val": {
+                                "vec": [
+                                  {
+                                    "map": [
+                                      {
+                                        "key": {
+                                          "symbol": "amount"
+                                        },
+                                        "val": {
+                                          "i128": {
+                                            "hi": 0,
+                                            "lo": 10000
+                                          }
+                                        }
+                                      },
+                                      {
+                                        "key": {
+                                          "symbol": "description"
+                                        },
+                                        "val": {
+                                          "symbol": "X"
+                                        }
+                                      },
+                                      {
+                                        "key": {
+                                          "symbol": "status"
+                                        },
+                                        "val": {
+                                          "vec": [
+                                            {
+                                              "symbol": "Pending"
+                                            }
+                                          ]
+                                        }
+                                      }
+                                    ]
+                                  }
+                                ]
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "recipient"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAITA4"
+                              }
+                            },
+                            {
+                              "key": {
+                                "symbol": "token_address"
+                              },
+                              "val": {
+                                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                              }
+                            }
+                          ]
+                        }
+                      ]
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_call"
+              },
+              {
+                "bytes": "0000000000000000000000000000000000000000000000000000000000000001"
+              },
+              {
+                "symbol": "get_escrow"
+              }
+            ],
+            "data": {
+              "u64": 201
+            }
+          }
+        }
+      },
+      "failed_call": false
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "fn_return"
+              },
+              {
+                "symbol": "get_escrow"
+              }
+            ],
+            "data": {
+              "error": {
+                "contract": 1
+              }
+            }
+          }
+        }
+      },
+      "failed_call": true
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "error"
+              },
+              {
+                "error": {
+                  "contract": 1
+                }
+              }
+            ],
+            "data": {
+              "string": "escalating Ok(ScErrorType::Contract) frame-exit to Err"
+            }
+          }
+        }
+      },
+      "failed_call": true
+    },
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": null,
+        "type_": "diagnostic",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "error"
+              },
+              {
+                "error": {
+                  "contract": 1
+                }
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "string": "contract try_call failed"
+                },
+                {
+                  "symbol": "get_escrow"
+                },
+                {
+                  "vec": [
+                    {
+                      "u64": 201
+                    }
+                  ]
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}

--- a/apps/onchain/test_snapshots/test/test_deposit_funds.1.json
+++ b/apps/onchain/test_snapshots/test/test_deposit_funds.1.json
@@ -285,7 +285,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "escrow"
+                  "symbol": "esc2"
                 },
                 {
                   "u64": 2
@@ -305,7 +305,7 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "escrow"
+                      "symbol": "esc2"
                     },
                     {
                       "u64": 2
@@ -337,6 +337,17 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_override_bps"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": -1,
+                          "lo": 18446744073709551615
+                        }
                       }
                     },
                     {
@@ -420,6 +431,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "packed_state"
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "recipient"
                       },
                       "val": {
@@ -432,30 +451,6 @@
                       },
                       "val": {
                         "u32": 1
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "resolution"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "None"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Active"
-                          }
-                        ]
                       }
                     },
                     {

--- a/apps/onchain/test_snapshots/test/test_deposit_funds_fails_when_paused.1.json
+++ b/apps/onchain/test_snapshots/test/test_deposit_funds_fails_when_paused.1.json
@@ -322,7 +322,7 @@
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": {
-              "symbol": "arbitrator"
+              "symbol": "arbi"
             },
             "durability": "persistent"
           }
@@ -335,7 +335,7 @@
                 "ext": "v0",
                 "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
                 "key": {
-                  "symbol": "arbitrator"
+                  "symbol": "arbi"
                 },
                 "durability": "persistent",
                 "val": {
@@ -353,7 +353,7 @@
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": {
-              "symbol": "operator"
+              "symbol": "oper"
             },
             "durability": "persistent"
           }
@@ -366,7 +366,7 @@
                 "ext": "v0",
                 "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
                 "key": {
-                  "symbol": "operator"
+                  "symbol": "oper"
                 },
                 "durability": "persistent",
                 "val": {
@@ -386,7 +386,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "escrow"
+                  "symbol": "esc2"
                 },
                 {
                   "u64": 1001
@@ -406,7 +406,7 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "escrow"
+                      "symbol": "esc2"
                     },
                     {
                       "u64": 1001
@@ -438,6 +438,17 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_override_bps"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": -1,
+                          "lo": 18446744073709551615
+                        }
                       }
                     },
                     {
@@ -486,6 +497,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "packed_state"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "recipient"
                       },
                       "val": {
@@ -498,30 +517,6 @@
                       },
                       "val": {
                         "u32": 1
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "resolution"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "None"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Created"
-                          }
-                        ]
                       }
                     },
                     {

--- a/apps/onchain/test_snapshots/test/test_dispute_blocks_release.1.json
+++ b/apps/onchain/test_snapshots/test/test_dispute_blocks_release.1.json
@@ -271,7 +271,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "escrow"
+                  "symbol": "esc2"
                 },
                 {
                   "u64": 9
@@ -291,7 +291,7 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "escrow"
+                      "symbol": "esc2"
                     },
                     {
                       "u64": 9
@@ -323,6 +323,17 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_override_bps"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": -1,
+                          "lo": 18446744073709551615
+                        }
                       }
                     },
                     {
@@ -371,6 +382,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "packed_state"
+                      },
+                      "val": {
+                        "u32": 4
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "recipient"
                       },
                       "val": {
@@ -383,30 +402,6 @@
                       },
                       "val": {
                         "u32": 1
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "resolution"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "None"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Disputed"
-                          }
-                        ]
                       }
                     },
                     {

--- a/apps/onchain/test_snapshots/test/test_double_confirm_delivery.1.json
+++ b/apps/onchain/test_snapshots/test/test_double_confirm_delivery.1.json
@@ -273,7 +273,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "escrow"
+                  "symbol": "esc2"
                 },
                 {
                   "u64": 10
@@ -293,7 +293,7 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "escrow"
+                      "symbol": "esc2"
                     },
                     {
                       "u64": 10
@@ -325,6 +325,17 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_override_bps"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": -1,
+                          "lo": 18446744073709551615
+                        }
                       }
                     },
                     {
@@ -373,6 +384,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "packed_state"
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "recipient"
                       },
                       "val": {
@@ -385,30 +404,6 @@
                       },
                       "val": {
                         "u32": 1
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "resolution"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "None"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Active"
-                          }
-                        ]
                       }
                     },
                     {

--- a/apps/onchain/test_snapshots/test/test_double_deposit_rejected.1.json
+++ b/apps/onchain/test_snapshots/test/test_double_deposit_rejected.1.json
@@ -248,7 +248,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "escrow"
+                  "symbol": "esc2"
                 },
                 {
                   "u64": 15
@@ -268,7 +268,7 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "escrow"
+                      "symbol": "esc2"
                     },
                     {
                       "u64": 15
@@ -300,6 +300,17 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_override_bps"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": -1,
+                          "lo": 18446744073709551615
+                        }
                       }
                     },
                     {
@@ -348,6 +359,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "packed_state"
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "recipient"
                       },
                       "val": {
@@ -360,30 +379,6 @@
                       },
                       "val": {
                         "u32": 1
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "resolution"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "None"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Active"
-                          }
-                        ]
                       }
                     },
                     {

--- a/apps/onchain/test_snapshots/test/test_double_release.1.json
+++ b/apps/onchain/test_snapshots/test/test_double_release.1.json
@@ -295,7 +295,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "escrow"
+                  "symbol": "esc2"
                 },
                 {
                   "u64": 8
@@ -315,7 +315,7 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "escrow"
+                      "symbol": "esc2"
                     },
                     {
                       "u64": 8
@@ -347,6 +347,17 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_override_bps"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": -1,
+                          "lo": 18446744073709551615
+                        }
                       }
                     },
                     {
@@ -395,6 +406,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "packed_state"
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "recipient"
                       },
                       "val": {
@@ -407,30 +426,6 @@
                       },
                       "val": {
                         "u32": 1
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "resolution"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "None"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Active"
-                          }
-                        ]
                       }
                     },
                     {

--- a/apps/onchain/test_snapshots/test/test_duplicate_escrow_id.1.json
+++ b/apps/onchain/test_snapshots/test/test_duplicate_escrow_id.1.json
@@ -198,7 +198,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "escrow"
+                  "symbol": "esc2"
                 },
                 {
                   "u64": 7
@@ -218,7 +218,7 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "escrow"
+                      "symbol": "esc2"
                     },
                     {
                       "u64": 7
@@ -250,6 +250,17 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_override_bps"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": -1,
+                          "lo": 18446744073709551615
+                        }
                       }
                     },
                     {
@@ -298,6 +309,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "packed_state"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "recipient"
                       },
                       "val": {
@@ -310,30 +329,6 @@
                       },
                       "val": {
                         "u32": 1
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "resolution"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "None"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Created"
-                          }
-                        ]
                       }
                     },
                     {

--- a/apps/onchain/test_snapshots/test/test_raise_dispute_happy_path.1.json
+++ b/apps/onchain/test_snapshots/test/test_raise_dispute_happy_path.1.json
@@ -255,7 +255,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "escrow"
+                  "symbol": "esc2"
                 },
                 {
                   "u64": 20
@@ -275,7 +275,7 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "escrow"
+                      "symbol": "esc2"
                     },
                     {
                       "u64": 20
@@ -307,6 +307,17 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_override_bps"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": -1,
+                          "lo": 18446744073709551615
+                        }
                       }
                     },
                     {
@@ -390,6 +401,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "packed_state"
+                      },
+                      "val": {
+                        "u32": 4
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "recipient"
                       },
                       "val": {
@@ -402,30 +421,6 @@
                       },
                       "val": {
                         "u32": 1
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "resolution"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "None"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Disputed"
-                          }
-                        ]
                       }
                     },
                     {

--- a/apps/onchain/test_snapshots/test/test_raise_dispute_invalid_status.1.json
+++ b/apps/onchain/test_snapshots/test/test_raise_dispute_invalid_status.1.json
@@ -432,7 +432,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "escrow"
+                  "symbol": "esc2"
                 },
                 {
                   "u64": 21
@@ -452,7 +452,7 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "escrow"
+                      "symbol": "esc2"
                     },
                     {
                       "u64": 21
@@ -484,6 +484,17 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_override_bps"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": -1,
+                          "lo": 18446744073709551615
+                        }
                       }
                     },
                     {
@@ -532,6 +543,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "packed_state"
+                      },
+                      "val": {
+                        "u32": 2
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "recipient"
                       },
                       "val": {
@@ -544,30 +563,6 @@
                       },
                       "val": {
                         "u32": 1
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "resolution"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "None"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Completed"
-                          }
-                        ]
                       }
                     },
                     {
@@ -627,7 +622,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "escrow"
+                  "symbol": "esc2"
                 },
                 {
                   "u64": 22
@@ -647,7 +642,7 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "escrow"
+                      "symbol": "esc2"
                     },
                     {
                       "u64": 22
@@ -679,6 +674,17 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_override_bps"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": -1,
+                          "lo": 18446744073709551615
+                        }
                       }
                     },
                     {
@@ -727,6 +733,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "packed_state"
+                      },
+                      "val": {
+                        "u32": 3
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "recipient"
                       },
                       "val": {
@@ -739,30 +753,6 @@
                       },
                       "val": {
                         "u32": 1
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "resolution"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "None"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Cancelled"
-                          }
-                        ]
                       }
                     },
                     {

--- a/apps/onchain/test_snapshots/test/test_refund_expired_authorization_check.1.json
+++ b/apps/onchain/test_snapshots/test/test_refund_expired_authorization_check.1.json
@@ -290,7 +290,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "escrow"
+                  "symbol": "esc2"
                 },
                 {
                   "u64": 100
@@ -310,7 +310,7 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "escrow"
+                      "symbol": "esc2"
                     },
                     {
                       "u64": 100
@@ -342,6 +342,17 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_override_bps"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": -1,
+                          "lo": 18446744073709551615
+                        }
                       }
                     },
                     {
@@ -390,6 +401,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "packed_state"
+                      },
+                      "val": {
+                        "u32": 6
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "recipient"
                       },
                       "val": {
@@ -402,30 +421,6 @@
                       },
                       "val": {
                         "u32": 1
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "resolution"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "None"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Expired"
-                          }
-                        ]
                       }
                     },
                     {

--- a/apps/onchain/test_snapshots/test/test_refund_expired_uses_escrow_fee_override.1.json
+++ b/apps/onchain/test_snapshots/test/test_refund_expired_uses_escrow_fee_override.1.json
@@ -352,7 +352,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "escfee"
+                  "symbol": "esc2"
                 },
                 {
                   "u64": 1
@@ -372,55 +372,7 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "escfee"
-                    },
-                    {
-                      "u64": 1
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 500
-                  }
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          4095
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "escrow"
-                },
-                {
-                  "u64": 1
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "escrow"
+                      "symbol": "esc2"
                     },
                     {
                       "u64": 1
@@ -452,6 +404,17 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_override_bps"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 500
+                        }
                       }
                     },
                     {
@@ -500,6 +463,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "packed_state"
+                      },
+                      "val": {
+                        "u32": 6
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "recipient"
                       },
                       "val": {
@@ -512,30 +483,6 @@
                       },
                       "val": {
                         "u32": 1
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "resolution"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "None"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Expired"
-                          }
-                        ]
                       }
                     },
                     {

--- a/apps/onchain/test_snapshots/test/test_release_milestone_above_threshold_insufficient_signatures.1.json
+++ b/apps/onchain/test_snapshots/test/test_release_milestone_above_threshold_insufficient_signatures.1.json
@@ -251,7 +251,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "escrow"
+                  "symbol": "esc2"
                 },
                 {
                   "u64": 103
@@ -271,7 +271,7 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "escrow"
+                      "symbol": "esc2"
                     },
                     {
                       "u64": 103
@@ -303,6 +303,17 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_override_bps"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": -1,
+                          "lo": 18446744073709551615
+                        }
                       }
                     },
                     {
@@ -351,6 +362,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "packed_state"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "recipient"
                       },
                       "val": {
@@ -363,30 +382,6 @@
                       },
                       "val": {
                         "u32": 2
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "resolution"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "None"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Created"
-                          }
-                        ]
                       }
                     },
                     {

--- a/apps/onchain/test_snapshots/test/test_release_milestone_above_threshold_sufficient_signatures.1.json
+++ b/apps/onchain/test_snapshots/test/test_release_milestone_above_threshold_sufficient_signatures.1.json
@@ -346,7 +346,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "escrow"
+                  "symbol": "esc2"
                 },
                 {
                   "u64": 104
@@ -366,7 +366,7 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "escrow"
+                      "symbol": "esc2"
                     },
                     {
                       "u64": 104
@@ -405,6 +405,17 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_override_bps"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": -1,
+                          "lo": 18446744073709551615
+                        }
                       }
                     },
                     {
@@ -453,6 +464,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "packed_state"
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "recipient"
                       },
                       "val": {
@@ -465,30 +484,6 @@
                       },
                       "val": {
                         "u32": 2
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "resolution"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "None"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Active"
-                          }
-                        ]
                       }
                     },
                     {

--- a/apps/onchain/test_snapshots/test/test_release_milestone_before_deposit.1.json
+++ b/apps/onchain/test_snapshots/test/test_release_milestone_before_deposit.1.json
@@ -173,7 +173,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "escrow"
+                  "symbol": "esc2"
                 },
                 {
                   "u64": 16
@@ -193,7 +193,7 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "escrow"
+                      "symbol": "esc2"
                     },
                     {
                       "u64": 16
@@ -225,6 +225,17 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_override_bps"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": -1,
+                          "lo": 18446744073709551615
+                        }
                       }
                     },
                     {
@@ -273,6 +284,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "packed_state"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "recipient"
                       },
                       "val": {
@@ -285,30 +304,6 @@
                       },
                       "val": {
                         "u32": 1
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "resolution"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "None"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Created"
-                          }
-                        ]
                       }
                     },
                     {

--- a/apps/onchain/test_snapshots/test/test_release_milestone_below_threshold_single_signature.1.json
+++ b/apps/onchain/test_snapshots/test/test_release_milestone_below_threshold_single_signature.1.json
@@ -323,7 +323,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "escrow"
+                  "symbol": "esc2"
                 },
                 {
                   "u64": 102
@@ -343,7 +343,7 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "escrow"
+                      "symbol": "esc2"
                     },
                     {
                       "u64": 102
@@ -375,6 +375,17 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_override_bps"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": -1,
+                          "lo": 18446744073709551615
+                        }
                       }
                     },
                     {
@@ -423,6 +434,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "packed_state"
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "recipient"
                       },
                       "val": {
@@ -435,30 +454,6 @@
                       },
                       "val": {
                         "u32": 2
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "resolution"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "None"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Active"
-                          }
-                        ]
                       }
                     },
                     {

--- a/apps/onchain/test_snapshots/test/test_release_milestone_uses_escrow_fee_override.1.json
+++ b/apps/onchain/test_snapshots/test/test_release_milestone_uses_escrow_fee_override.1.json
@@ -377,7 +377,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "escfee"
+                  "symbol": "esc2"
                 },
                 {
                   "u64": 1
@@ -397,55 +397,7 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "escfee"
-                    },
-                    {
-                      "u64": 1
-                    }
-                  ]
-                },
-                "durability": "persistent",
-                "val": {
-                  "i128": {
-                    "hi": 0,
-                    "lo": 300
-                  }
-                }
-              }
-            },
-            "ext": "v0"
-          },
-          4095
-        ]
-      ],
-      [
-        {
-          "contract_data": {
-            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-            "key": {
-              "vec": [
-                {
-                  "symbol": "escrow"
-                },
-                {
-                  "u64": 1
-                }
-              ]
-            },
-            "durability": "persistent"
-          }
-        },
-        [
-          {
-            "last_modified_ledger_seq": 0,
-            "data": {
-              "contract_data": {
-                "ext": "v0",
-                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
-                "key": {
-                  "vec": [
-                    {
-                      "symbol": "escrow"
+                      "symbol": "esc2"
                     },
                     {
                       "u64": 1
@@ -477,6 +429,17 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_override_bps"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": 0,
+                          "lo": 300
+                        }
                       }
                     },
                     {
@@ -525,6 +488,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "packed_state"
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "recipient"
                       },
                       "val": {
@@ -537,30 +508,6 @@
                       },
                       "val": {
                         "u32": 1
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "resolution"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "None"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Active"
-                          }
-                        ]
                       }
                     },
                     {

--- a/apps/onchain/test_snapshots/test/test_release_milestone_uses_global_fee_by_default.1.json
+++ b/apps/onchain/test_snapshots/test/test_release_milestone_uses_global_fee_by_default.1.json
@@ -296,7 +296,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "escrow"
+                  "symbol": "esc2"
                 },
                 {
                   "u64": 1
@@ -316,7 +316,7 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "escrow"
+                      "symbol": "esc2"
                     },
                     {
                       "u64": 1
@@ -348,6 +348,17 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_override_bps"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": -1,
+                          "lo": 18446744073709551615
+                        }
                       }
                     },
                     {
@@ -396,6 +407,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "packed_state"
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "recipient"
                       },
                       "val": {
@@ -408,30 +427,6 @@
                       },
                       "val": {
                         "u32": 1
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "resolution"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "None"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Active"
-                          }
-                        ]
                       }
                     },
                     {

--- a/apps/onchain/test_snapshots/test/test_release_milestone_uses_token_fee_override.1.json
+++ b/apps/onchain/test_snapshots/test/test_release_milestone_uses_token_fee_override.1.json
@@ -352,7 +352,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "escrow"
+                  "symbol": "esc2"
                 },
                 {
                   "u64": 1
@@ -372,7 +372,7 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "escrow"
+                      "symbol": "esc2"
                     },
                     {
                       "u64": 1
@@ -404,6 +404,17 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_override_bps"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": -1,
+                          "lo": 18446744073709551615
+                        }
                       }
                     },
                     {
@@ -452,6 +463,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "packed_state"
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "recipient"
                       },
                       "val": {
@@ -464,30 +483,6 @@
                       },
                       "val": {
                         "u32": 1
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "resolution"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "None"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Active"
-                          }
-                        ]
                       }
                     },
                     {

--- a/apps/onchain/test_snapshots/test/test_release_milestone_with_tokens.1.json
+++ b/apps/onchain/test_snapshots/test/test_release_milestone_with_tokens.1.json
@@ -336,7 +336,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "escrow"
+                  "symbol": "esc2"
                 },
                 {
                   "u64": 3
@@ -356,7 +356,7 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "escrow"
+                      "symbol": "esc2"
                     },
                     {
                       "u64": 3
@@ -388,6 +388,17 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_override_bps"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": -1,
+                          "lo": 18446744073709551615
+                        }
                       }
                     },
                     {
@@ -471,6 +482,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "packed_state"
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "recipient"
                       },
                       "val": {
@@ -483,30 +502,6 @@
                       },
                       "val": {
                         "u32": 1
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "resolution"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "None"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Active"
-                          }
-                        ]
                       }
                     },
                     {

--- a/apps/onchain/test_snapshots/test/test_resolve_dispute_fails_without_arbitrator_initialized.1.json
+++ b/apps/onchain/test_snapshots/test/test_resolve_dispute_fails_without_arbitrator_initialized.1.json
@@ -270,7 +270,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "escrow"
+                  "symbol": "esc2"
                 },
                 {
                   "u64": 1
@@ -290,7 +290,7 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "escrow"
+                      "symbol": "esc2"
                     },
                     {
                       "u64": 1
@@ -322,6 +322,17 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_override_bps"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": -1,
+                          "lo": 18446744073709551615
+                        }
                       }
                     },
                     {
@@ -370,6 +381,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "packed_state"
+                      },
+                      "val": {
+                        "u32": 4
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "recipient"
                       },
                       "val": {
@@ -382,30 +401,6 @@
                       },
                       "val": {
                         "u32": 1
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "resolution"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "None"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Disputed"
-                          }
-                        ]
                       }
                     },
                     {

--- a/apps/onchain/test_snapshots/test/test_resolve_dispute_invalid_winner_or_overflow.1.json
+++ b/apps/onchain/test_snapshots/test/test_resolve_dispute_invalid_winner_or_overflow.1.json
@@ -324,7 +324,7 @@
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": {
-              "symbol": "arbitrator"
+              "symbol": "arbi"
             },
             "durability": "persistent"
           }
@@ -337,7 +337,7 @@
                 "ext": "v0",
                 "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
                 "key": {
-                  "symbol": "arbitrator"
+                  "symbol": "arbi"
                 },
                 "durability": "persistent",
                 "val": {
@@ -355,7 +355,7 @@
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": {
-              "symbol": "operator"
+              "symbol": "oper"
             },
             "durability": "persistent"
           }
@@ -368,7 +368,7 @@
                 "ext": "v0",
                 "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
                 "key": {
-                  "symbol": "operator"
+                  "symbol": "oper"
                 },
                 "durability": "persistent",
                 "val": {
@@ -388,7 +388,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "escrow"
+                  "symbol": "esc2"
                 },
                 {
                   "u64": 24
@@ -408,7 +408,7 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "escrow"
+                      "symbol": "esc2"
                     },
                     {
                       "u64": 24
@@ -440,6 +440,17 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAK3IM"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_override_bps"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": -1,
+                          "lo": 18446744073709551615
+                        }
                       }
                     },
                     {
@@ -488,6 +499,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "packed_state"
+                      },
+                      "val": {
+                        "u32": 4
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "recipient"
                       },
                       "val": {
@@ -500,30 +519,6 @@
                       },
                       "val": {
                         "u32": 1
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "resolution"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "None"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Disputed"
-                          }
-                        ]
                       }
                     },
                     {

--- a/apps/onchain/test_snapshots/test/test_resolve_dispute_while_paused.1.json
+++ b/apps/onchain/test_snapshots/test/test_resolve_dispute_while_paused.1.json
@@ -386,7 +386,7 @@
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": {
-              "symbol": "arbitrator"
+              "symbol": "arbi"
             },
             "durability": "persistent"
           }
@@ -399,7 +399,7 @@
                 "ext": "v0",
                 "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
                 "key": {
-                  "symbol": "arbitrator"
+                  "symbol": "arbi"
                 },
                 "durability": "persistent",
                 "val": {
@@ -417,7 +417,7 @@
           "contract_data": {
             "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
             "key": {
-              "symbol": "operator"
+              "symbol": "oper"
             },
             "durability": "persistent"
           }
@@ -430,7 +430,7 @@
                 "ext": "v0",
                 "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
                 "key": {
-                  "symbol": "operator"
+                  "symbol": "oper"
                 },
                 "durability": "persistent",
                 "val": {
@@ -450,7 +450,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "escrow"
+                  "symbol": "esc2"
                 },
                 {
                   "u64": 25
@@ -470,7 +470,7 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "escrow"
+                      "symbol": "esc2"
                     },
                     {
                       "u64": 25
@@ -502,6 +502,17 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAMDR4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_override_bps"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": -1,
+                          "lo": 18446744073709551615
+                        }
                       }
                     },
                     {
@@ -550,6 +561,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "packed_state"
+                      },
+                      "val": {
+                        "u32": 13
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "recipient"
                       },
                       "val": {
@@ -562,30 +581,6 @@
                       },
                       "val": {
                         "u32": 1
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "resolution"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Depositor"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Resolved"
-                          }
-                        ]
                       }
                     },
                     {

--- a/apps/onchain/test_snapshots/test/test_unauthorized_confirm_delivery.1.json
+++ b/apps/onchain/test_snapshots/test/test_unauthorized_confirm_delivery.1.json
@@ -248,7 +248,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "escrow"
+                  "symbol": "esc2"
                 },
                 {
                   "u64": 9
@@ -268,7 +268,7 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "escrow"
+                      "symbol": "esc2"
                     },
                     {
                       "u64": 9
@@ -300,6 +300,17 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_override_bps"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": -1,
+                          "lo": 18446744073709551615
+                        }
                       }
                     },
                     {
@@ -348,6 +359,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "packed_state"
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "recipient"
                       },
                       "val": {
@@ -360,30 +379,6 @@
                       },
                       "val": {
                         "u32": 1
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "resolution"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "None"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Active"
-                          }
-                        ]
                       }
                     },
                     {

--- a/apps/onchain/test_snapshots/test/test_valid_escrow_creation_succeeds.1.json
+++ b/apps/onchain/test_snapshots/test/test_valid_escrow_creation_succeeds.1.json
@@ -233,7 +233,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "escrow"
+                  "symbol": "esc2"
                 },
                 {
                   "u64": 14
@@ -253,7 +253,7 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "escrow"
+                      "symbol": "esc2"
                     },
                     {
                       "u64": 14
@@ -285,6 +285,17 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_override_bps"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": -1,
+                          "lo": 18446744073709551615
+                        }
                       }
                     },
                     {
@@ -368,6 +379,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "packed_state"
+                      },
+                      "val": {
+                        "u32": 0
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "recipient"
                       },
                       "val": {
@@ -380,30 +399,6 @@
                       },
                       "val": {
                         "u32": 1
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "resolution"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "None"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Created"
-                          }
-                        ]
                       }
                     },
                     {

--- a/apps/onchain/test_snapshots/test/test_zero_fee_valid.1.json
+++ b/apps/onchain/test_snapshots/test/test_zero_fee_valid.1.json
@@ -352,7 +352,7 @@
             "key": {
               "vec": [
                 {
-                  "symbol": "escrow"
+                  "symbol": "esc2"
                 },
                 {
                   "u64": 1
@@ -372,7 +372,7 @@
                 "key": {
                   "vec": [
                     {
-                      "symbol": "escrow"
+                      "symbol": "esc2"
                     },
                     {
                       "u64": 1
@@ -404,6 +404,17 @@
                       },
                       "val": {
                         "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                      }
+                    },
+                    {
+                      "key": {
+                        "symbol": "fee_override_bps"
+                      },
+                      "val": {
+                        "i128": {
+                          "hi": -1,
+                          "lo": 18446744073709551615
+                        }
                       }
                     },
                     {
@@ -452,6 +463,14 @@
                     },
                     {
                       "key": {
+                        "symbol": "packed_state"
+                      },
+                      "val": {
+                        "u32": 1
+                      }
+                    },
+                    {
+                      "key": {
                         "symbol": "recipient"
                       },
                       "val": {
@@ -464,30 +483,6 @@
                       },
                       "val": {
                         "u32": 1
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "resolution"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "None"
-                          }
-                        ]
-                      }
-                    },
-                    {
-                      "key": {
-                        "symbol": "status"
-                      },
-                      "val": {
-                        "vec": [
-                          {
-                            "symbol": "Active"
-                          }
-                        ]
                       }
                     },
                     {


### PR DESCRIPTION
PR message

- Adds create_escrows_batch to create multiple escrows in one transaction with all-or-nothing behavior.
- Emits a single EscrowsCreatedBatch event with summarized per-escrow items to reduce event overhead.
- Optimizes persistent storage/rent by migrating escrows to a v2 record, packing status+resolution into a bitmask, and using more granular TTL extension.
- Runs clean with cargo fmt , cargo clippy --all-targets -- -D warnings , and cargo test .

closes #137 
closes #134 