### PR TITLE
fix: replace string literals with real Albedo SDK calls in albedo.ts

### DIFF
--- a/apps/frontend/app/services/wallet/albedo.ts
+++ b/apps/frontend/app/services/wallet/albedo.ts
@@ -1,5 +1,4 @@
-// Import albedo correctly
-
+import albedo from '@albedo-link/intent';
 
 export interface AlbedoIntentResult {
   signed_envelope_xdr?: string;
@@ -21,38 +20,47 @@ export class AlbedoService {
 
   async connect(): Promise<string> {
     try {
-      const result = await this.publicKey()
+      const result = await this.publicKey();
       return result;
     } catch (error: any) {
+      if (error.message?.includes('rejected')) {
+        throw new Error('Albedo connection was rejected by the user.');
+      }
       throw new Error(`Failed to connect with Albedo: ${error.message}`);
     }
   }
 
   async signTransaction(xdr: string): Promise<string> {
     try {
-      const result = await "await albedo.signTransaction({xdr, network: this.getNetworkParam()});"
-      
-      if (!result) {
+      const result = await albedo.tx({ xdr, network: this.getNetworkParam() });
+
+      if (!result.signed_envelope_xdr) {
         throw new Error('No signed envelope returned from Albedo');
       }
-      
-      return result;
+
+      return result.signed_envelope_xdr;
     } catch (error: any) {
+      if (error.message?.includes('rejected')) {
+        throw new Error('Transaction signing was rejected by the user.');
+      }
       throw new Error(`Failed to sign transaction with Albedo: ${error.message}`);
     }
   }
 
-  private getNetworkParam(): string {
+  private getNetworkParam(): 'public' | 'testnet' {
     const network = process.env.NEXT_PUBLIC_STELLAR_NETWORK || 'testnet';
     return network === 'mainnet' ? 'public' : 'testnet';
   }
 
   private async publicKey(): Promise<string> {
     try {
-      const result = "await albedo.publicKey({});"
-      return result;
+      const result = await albedo.publicKey({});
+      return result.pubkey;
     } catch (error: any) {
+      if (error.message?.includes('rejected')) {
+        throw new Error('Albedo connection was rejected by the user.');
+      }
       throw new Error(`Failed to get public key from Albedo: ${error.message}`);
-    }   
     }
+  }
 }

--- a/apps/frontend/package-lock.json
+++ b/apps/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "@albedo-link/intent": "^0.13.0",
         "@hookform/resolvers": "^5.2.2",
         "@stellar/freighter-api": "^6.0.1",
         "@tanstack/react-query": "^5.90.20",
@@ -37,6 +38,12 @@
         "tw-animate-css": "^1.4.0",
         "typescript": "^5"
       }
+    },
+    "node_modules/@albedo-link/intent": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@albedo-link/intent/-/intent-0.13.0.tgz",
+      "integrity": "sha512-A8CBXqGQEBMXhwxNXj5inC6HLjyx5Do7jW99NOFeecYd1nPUq8gfM0tvoNoR8H8JQ11aTl9tyQBuu/+l3xeBnQ==",
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",

--- a/apps/frontend/package.json
+++ b/apps/frontend/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "@albedo-link/intent": "^0.13.0",
     "@hookform/resolvers": "^5.2.2",
     "@stellar/freighter-api": "^6.0.1",
     "@tanstack/react-query": "^5.90.20",


### PR DESCRIPTION
- Install @albedo-link/intent package
- Import albedo default export and call albedo.publicKey({}) and albedo.tx() instead of string literals that were assigned but never executed
- Extract pubkey from publicKey() result and signed_envelope_xdr from tx() result
- Add user rejection error handling in connect(), publicKey(), and signTransaction()
- Tighten getNetworkParam() return type to match SDK's StellarNetwork type

Closes #140