### PR TITLE
feat(frontend): add Lobstr to unified wallet connection selector modal

### DIFF
--- a/apps/frontend/app/services/wallet/index.ts
+++ b/apps/frontend/app/services/wallet/index.ts
@@ -1,9 +1,11 @@
 import { FreighterService } from './freighter';
 import { AlbedoService } from './albedo';
+import { LobstrService } from './lobstr';
 
 export enum WalletType {
   FREIGHTER = 'freighter',
   ALBEDO = 'albedo',
+  LOBSTR = 'lobstr',
 }
 
 export interface WalletConnection {
@@ -27,6 +29,8 @@ export class WalletServiceFactory {
         return FreighterService.getInstance();
       case WalletType.ALBEDO:
         return AlbedoService.getInstance();
+      case WalletType.LOBSTR:
+        return LobstrService.getInstance();
       default:
         throw new Error(`Unsupported wallet type: ${walletType}`);
     }
@@ -34,7 +38,7 @@ export class WalletServiceFactory {
 
   static async getAvailableWallets(): Promise<WalletType[]> {
     const availableWallets: WalletType[] = [];
-    
+
     // Check for Freighter
     const freighterService = FreighterService.getInstance();
     try {
@@ -44,10 +48,20 @@ export class WalletServiceFactory {
     } catch {
       // Freighter not available
     }
-    
+
     // Albedo is always available as it's a web-based wallet
     availableWallets.push(WalletType.ALBEDO);
-    
+
+    // Check for Lobstr
+    const lobstrService = LobstrService.getInstance();
+    try {
+      if (await lobstrService.isInstalled?.()) {
+        availableWallets.push(WalletType.LOBSTR);
+      }
+    } catch {
+      // Lobstr not available
+    }
+
     return availableWallets;
   }
 }

--- a/apps/frontend/app/services/wallet/lobstr.ts
+++ b/apps/frontend/app/services/wallet/lobstr.ts
@@ -1,0 +1,51 @@
+declare global {
+  interface Window {
+    lobstr?: any;
+  }
+}
+
+export class LobstrService {
+  private static instance: LobstrService;
+
+  private constructor() {}
+
+  public static getInstance(): LobstrService {
+    if (!LobstrService.instance) {
+      LobstrService.instance = new LobstrService();
+    }
+    return LobstrService.instance;
+  }
+
+  async isInstalled(): Promise<boolean> {
+    try {
+      if (typeof window === 'undefined') return false;
+      return !!window.lobstr;
+    } catch {
+      return false;
+    }
+  }
+
+  async connect(): Promise<string> {
+    if (typeof window === 'undefined' || !window.lobstr) {
+      throw new Error('Lobstr wallet is not installed');
+    }
+    try {
+      const publicKey = await window.lobstr.getPublicKey();
+      return publicKey;
+    } catch (error: any) {
+      throw new Error(`Failed to connect to Lobstr: ${error.message}`);
+    }
+  }
+
+  async signTransaction(xdr: string): Promise<string> {
+    if (typeof window === 'undefined' || !window.lobstr) {
+      throw new Error('Lobstr wallet is not installed');
+    }
+    try {
+      const signedXdr = await window.lobstr.signTransaction(xdr);
+      return signedXdr;
+    } catch (error: any) {
+      throw new Error(`Failed to sign transaction with Lobstr: ${error.message}`);
+    }
+  }
+}

--- a/apps/frontend/component/wallet/ConnectWalletModal.tsx
+++ b/apps/frontend/component/wallet/ConnectWalletModal.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useEffect } from 'react';
-import { X, ExternalLink, Check } from 'lucide-react';
+import { X, ExternalLink, Check, Loader2 } from 'lucide-react';
 import { useWallet } from '@/app/contexts/WalletContext';
 
 interface ConnectWalletModalProps {
@@ -9,49 +9,49 @@ interface ConnectWalletModalProps {
   onClose: () => void;
 }
 
-const WalletType = {
-  FREIGHTER: 'freighter',
-  ALBEDO: 'albedo',
-};
-
 const WALLET_INFO = {
-  [WalletType.FREIGHTER]: {
+  freighter: {
     name: 'Freighter',
     description: 'Browser extension wallet',
     icon: '🚀',
     installUrl: 'https://www.freighter.app/',
+    alwaysAvailable: false,
   },
-  [WalletType.ALBEDO]: {
+  albedo: {
     name: 'Albedo',
-    description: 'Web-based wallet',
+    description: 'Web-based wallet — no extension needed',
     icon: '✨',
     installUrl: 'https://albedo.link/',
+    alwaysAvailable: true,
   },
-};
+  lobstr: {
+    name: 'Lobstr',
+    description: 'Browser extension wallet',
+    icon: '🦞',
+    installUrl: 'https://lobstr.co/vault/',
+    alwaysAvailable: false,
+  },
+} as const;
+
+type WalletKey = keyof typeof WALLET_INFO;
 
 export const ConnectWalletModal: React.FC<ConnectWalletModalProps> = ({ isOpen, onClose }) => {
   const { connect, getAvailableWallets, isConnecting, error } = useWallet();
-  const [availableWallets, setAvailableWallets] = useState<any[]>([]);
-  const [selectedWallet, setSelectedWallet] = useState<any | null>(null);
+  const [availableWallets, setAvailableWallets] = useState<string[]>([]);
+  const [selectedWallet, setSelectedWallet] = useState<string | null>(null);
 
   useEffect(() => {
-    const loadAvailableWallets = async () => {
-      const wallets = await getAvailableWallets();
-      setAvailableWallets(wallets);
-    };
-
-    if (isOpen) {
-      loadAvailableWallets();
-    }
+    if (!isOpen) return;
+    getAvailableWallets().then((wallets) => setAvailableWallets(wallets));
   }, [isOpen, getAvailableWallets]);
 
-  const handleConnect = async (walletType: any) => {
+  const handleConnect = async (walletType: string) => {
     try {
       setSelectedWallet(walletType);
-      await connect(walletType);
+      await connect(walletType as any);
       onClose();
-    } catch (err) {
-      // Error is handled by context
+    } catch {
+      // Error surfaced via context
     } finally {
       setSelectedWallet(null);
     }
@@ -66,14 +66,9 @@ export const ConnectWalletModal: React.FC<ConnectWalletModalProps> = ({ isOpen, 
         <div className="flex items-center justify-between mb-6">
           <div>
             <h2 className="text-2xl font-bold text-white">Connect Wallet</h2>
-            <p className="text-gray-400 text-sm mt-1">
-              Choose a wallet to connect to Vaultix
-            </p>
+            <p className="text-gray-400 text-sm mt-1">Choose a wallet to connect to Vaultix</p>
           </div>
-          <button
-            onClick={onClose}
-            className="p-2 rounded-lg hover:bg-gray-700 transition-colors"
-          >
+          <button onClick={onClose} className="p-2 rounded-lg hover:bg-gray-700 transition-colors">
             <X className="w-5 h-5 text-gray-400" />
           </button>
         </div>
@@ -87,31 +82,34 @@ export const ConnectWalletModal: React.FC<ConnectWalletModalProps> = ({ isOpen, 
 
         {/* Wallet Options */}
         <div className="space-y-3">
-          {Object.entries(WALLET_INFO).map(([type, info]) => {
-            const walletType = type as any;
-            const isAvailable = availableWallets.includes(walletType);
-            const isInstalling = selectedWallet === walletType && isConnecting;
+          {(Object.entries(WALLET_INFO) as [WalletKey, typeof WALLET_INFO[WalletKey]][]).map(([type, info]) => {
+            const isAvailable = info.alwaysAvailable || availableWallets.includes(type);
+            const isConnectingThis = selectedWallet === type && isConnecting;
 
             return (
               <button
-                key={walletType}
-                onClick={() => isAvailable && handleConnect(walletType)}
+                key={type}
+                onClick={() => isAvailable && handleConnect(type)}
                 disabled={!isAvailable || isConnecting}
-                className={`w-full flex items-center justify-between p-4 rounded-xl transition-all duration-200 ${isAvailable
+                className={`w-full flex items-center justify-between p-4 rounded-xl transition-all duration-200 border border-gray-700 ${
+                  isAvailable
                     ? 'bg-gray-800 hover:bg-gray-700 hover:scale-[1.02] active:scale-[0.98]'
                     : 'bg-gray-900/50 opacity-60 cursor-not-allowed'
-                  } border border-gray-700`}
+                }`}
               >
                 <div className="flex items-center space-x-4">
                   <div className="text-2xl">{info.icon}</div>
                   <div className="text-left">
                     <div className="flex items-center space-x-2">
-                      <span className="font-semibold text-white">
-                        {info.name}
-                      </span>
-                      {!isAvailable && walletType === WalletType.FREIGHTER && (
-                        <span className="text-xs px-2 py-1 bg-yellow-500/20 text-yellow-400 rounded-full">
+                      <span className="font-semibold text-white">{info.name}</span>
+                      {!isAvailable && (
+                        <span className="text-xs px-2 py-0.5 bg-yellow-500/20 text-yellow-400 rounded-full">
                           Not installed
+                        </span>
+                      )}
+                      {isAvailable && !isConnectingThis && (
+                        <span className="text-xs px-2 py-0.5 bg-green-500/20 text-green-400 rounded-full">
+                          Ready
                         </span>
                       )}
                     </div>
@@ -119,17 +117,17 @@ export const ConnectWalletModal: React.FC<ConnectWalletModalProps> = ({ isOpen, 
                   </div>
                 </div>
 
-                <div className="flex items-center space-x-2">
-                  {isInstalling && (
-                    <div className="flex items-center space-x-2">
-                      <div className="w-2 h-2 bg-blue-400 rounded-full animate-pulse" />
-                      <span className="text-sm text-blue-400">Connecting...</span>
+                <div className="flex items-center space-x-2 flex-shrink-0">
+                  {isConnectingThis && (
+                    <div className="flex items-center space-x-1 text-blue-400">
+                      <Loader2 className="w-4 h-4 animate-spin" />
+                      <span className="text-sm">Connecting…</span>
                     </div>
                   )}
-                  {isAvailable && !isInstalling && (
+                  {isAvailable && !isConnectingThis && (
                     <Check className="w-5 h-5 text-green-400" />
                   )}
-                  {!isAvailable && walletType === WalletType.FREIGHTER && (
+                  {!isAvailable && (
                     <a
                       href={info.installUrl}
                       target="_blank"


### PR DESCRIPTION
## Summary

- Added `LobstrService` implementing connect and signTransaction via the `window.lobstr` extension API
- Registered `LOBSTR` in the `WalletType` enum and `WalletServiceFactory`
- Updated `ConnectWalletModal` to list all three providers (Freighter, Albedo, Lobstr) with real-time installed/ready/not-installed status badges
- Added install links for providers that are not detected
- Wallet preference persistence (localStorage) already handled by `WalletContext`

## Test plan

- [ ] Open the wallet modal — all three providers (Freighter, Albedo, Lobstr) are listed
- [ ] With no extensions installed, Freighter and Lobstr show "Not installed" with an install link; Albedo shows "Ready"
- [ ] Clicking Albedo initiates the Albedo web connection flow
- [ ] With Freighter installed, clicking it connects and stores the preference in localStorage
- [ ] With Lobstr installed, clicking it connects and stores the preference

Closes #186