### PR TITLE
feat(frontend): add Milestones and Conditions steps to escrow creation wizard

### DIFF
--- a/apps/frontend/component/escrow/CreateEscrowWizard.tsx
+++ b/apps/frontend/component/escrow/CreateEscrowWizard.tsx
@@ -9,6 +9,8 @@ import { createEscrowSchema, CreateEscrowFormData } from '@/lib/escrow-schema';
 import BasicInfoStep from './create/BasicInfoStep';
 import PartiesStep from './create/PartiesStep';
 import TermsStep from './create/TermsStep';
+import MilestonesStep from './create/MilestonesStep';
+import ConditionsStep from './create/ConditionsStep';
 import ReviewStep from './create/ReviewStep';
 import { CheckCircle2, ChevronRight, ChevronLeft, Loader2, AlertCircle } from 'lucide-react';
 import { isConnected, signTransaction, getAddress } from '@stellar/freighter-api';
@@ -18,6 +20,8 @@ const STEPS = [
   { id: 'basic', title: 'Basic Info', fields: ['title', 'description', 'category'] },
   { id: 'parties', title: 'Parties', fields: ['counterpartyAddress'] },
   { id: 'terms', title: 'Terms', fields: ['amount', 'deadline', 'asset'] },
+  { id: 'milestones', title: 'Milestones', fields: [] },
+  { id: 'conditions', title: 'Conditions', fields: [] },
   { id: 'review', title: 'Review', fields: [] },
 ];
 
@@ -182,7 +186,9 @@ export default function CreateEscrowWizard() {
               {currentStep === 0 && <BasicInfoStep />}
               {currentStep === 1 && <PartiesStep />}
               {currentStep === 2 && <TermsStep />}
-              {currentStep === 3 && <ReviewStep />}
+              {currentStep === 3 && <MilestonesStep />}
+              {currentStep === 4 && <ConditionsStep />}
+              {currentStep === 5 && <ReviewStep />}
             </div>
 
             {/* Error Message */}

--- a/apps/frontend/component/escrow/CreateEscrowWizard.tsx
+++ b/apps/frontend/component/escrow/CreateEscrowWizard.tsx
@@ -36,6 +36,8 @@ export default function CreateEscrowWizard() {
     mode: 'onChange',
     defaultValues: {
       asset: 'XLM',
+      milestones: [],
+      conditions: [],
     }
   });
 

--- a/apps/frontend/component/escrow/create/ConditionsStep.tsx
+++ b/apps/frontend/component/escrow/create/ConditionsStep.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import { useFormContext, useFieldArray } from 'react-hook-form';
+import { CreateEscrowFormData } from '@/lib/escrow-schema';
+import { PlusCircle, Trash2 } from 'lucide-react';
+
+const CONDITION_TYPES = [
+  { value: 'manual', label: 'Manual — a party manually confirms completion' },
+  { value: 'time', label: 'Time-based — releases after a specific date/time' },
+  { value: 'oracle', label: 'Oracle — an external oracle signals completion' },
+];
+
+export default function ConditionsStep() {
+  const {
+    register,
+    control,
+    watch,
+    formState: { errors },
+  } = useFormContext<CreateEscrowFormData>();
+
+  const { fields, append, remove } = useFieldArray({ control, name: 'conditions' });
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-xl font-semibold text-gray-900">Release Conditions</h2>
+        <p className="mt-1 text-sm text-gray-500">
+          Define the conditions that must be met before funds are released. Leave empty for a fully manual escrow.
+        </p>
+      </div>
+
+      {fields.length === 0 && (
+        <p className="text-sm text-gray-400 italic">No conditions added. Funds will be released manually by the parties.</p>
+      )}
+
+      <div className="space-y-4">
+        {fields.map((field, index) => {
+          const conditionType = watch(`conditions.${index}.type`);
+          return (
+            <div key={field.id} className="border border-gray-200 rounded-lg p-4 space-y-3 bg-gray-50">
+              <div className="flex items-center justify-between">
+                <span className="text-sm font-medium text-gray-700">Condition {index + 1}</span>
+                <button
+                  type="button"
+                  onClick={() => remove(index)}
+                  className="text-red-400 hover:text-red-600 transition-colors"
+                >
+                  <Trash2 className="w-4 h-4" />
+                </button>
+              </div>
+
+              <div>
+                <label className="block text-xs font-medium text-gray-600 mb-1">Type</label>
+                <select
+                  {...register(`conditions.${index}.type`)}
+                  className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500 bg-white"
+                >
+                  {CONDITION_TYPES.map((ct) => (
+                    <option key={ct.value} value={ct.value}>{ct.label}</option>
+                  ))}
+                </select>
+              </div>
+
+              <div>
+                <label className="block text-xs font-medium text-gray-600 mb-1">Description</label>
+                <input
+                  {...register(`conditions.${index}.description`)}
+                  placeholder="Describe the condition"
+                  className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                />
+              </div>
+
+              {conditionType === 'time' && (
+                <div>
+                  <label className="block text-xs font-medium text-gray-600 mb-1">Release Date</label>
+                  <input
+                    {...register(`conditions.${index}.releaseDate`)}
+                    type="datetime-local"
+                    className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+                  />
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+
+      <button
+        type="button"
+        onClick={() => append({ type: 'manual', description: '', releaseDate: '' })}
+        className="flex items-center space-x-2 text-sm text-blue-600 hover:text-blue-700 font-medium"
+      >
+        <PlusCircle className="w-4 h-4" />
+        <span>Add Condition</span>
+      </button>
+    </div>
+  );
+}

--- a/apps/frontend/component/escrow/create/MilestonesStep.tsx
+++ b/apps/frontend/component/escrow/create/MilestonesStep.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { useFormContext, useFieldArray } from 'react-hook-form';
+import { CreateEscrowFormData } from '@/lib/escrow-schema';
+import { PlusCircle, Trash2 } from 'lucide-react';
+
+export default function MilestonesStep() {
+  const {
+    register,
+    control,
+    formState: { errors },
+  } = useFormContext<CreateEscrowFormData>();
+
+  const { fields, append, remove } = useFieldArray({ control, name: 'milestones' });
+
+  return (
+    <div className="space-y-6">
+      <div>
+        <h2 className="text-xl font-semibold text-gray-900">Milestones</h2>
+        <p className="mt-1 text-sm text-gray-500">
+          Break the escrow into milestones. Each milestone amount will be released when its condition is met.
+        </p>
+      </div>
+
+      {fields.length === 0 && (
+        <p className="text-sm text-gray-400 italic">No milestones added yet. Add one below, or skip to use a single-payment escrow.</p>
+      )}
+
+      <div className="space-y-4">
+        {fields.map((field, index) => (
+          <div key={field.id} className="border border-gray-200 rounded-lg p-4 space-y-3 bg-gray-50">
+            <div className="flex items-center justify-between">
+              <span className="text-sm font-medium text-gray-700">Milestone {index + 1}</span>
+              <button
+                type="button"
+                onClick={() => remove(index)}
+                className="text-red-400 hover:text-red-600 transition-colors"
+              >
+                <Trash2 className="w-4 h-4" />
+              </button>
+            </div>
+
+            <div>
+              <label className="block text-xs font-medium text-gray-600 mb-1">Description</label>
+              <input
+                {...register(`milestones.${index}.description`)}
+                placeholder="e.g. Initial design delivered"
+                className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+              {errors.milestones?.[index]?.description && (
+                <p className="mt-1 text-xs text-red-500">{errors.milestones[index]!.description!.message}</p>
+              )}
+            </div>
+
+            <div>
+              <label className="block text-xs font-medium text-gray-600 mb-1">Amount (XLM)</label>
+              <input
+                {...register(`milestones.${index}.amount`)}
+                placeholder="0.00"
+                type="number"
+                min="0"
+                step="0.01"
+                className="w-full border border-gray-300 rounded-md px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+              />
+              {errors.milestones?.[index]?.amount && (
+                <p className="mt-1 text-xs text-red-500">{errors.milestones[index]!.amount!.message}</p>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+
+      <button
+        type="button"
+        onClick={() => append({ description: '', amount: '' })}
+        className="flex items-center space-x-2 text-sm text-blue-600 hover:text-blue-700 font-medium"
+      >
+        <PlusCircle className="w-4 h-4" />
+        <span>Add Milestone</span>
+      </button>
+    </div>
+  );
+}

--- a/apps/frontend/component/escrow/create/ReviewStep.tsx
+++ b/apps/frontend/component/escrow/create/ReviewStep.tsx
@@ -15,6 +15,9 @@ export default function ReviewStep() {
     }).format(date);
   };
 
+  const milestones = values.milestones ?? [];
+  const conditions = values.conditions ?? [];
+
   return (
     <div className="space-y-6">
       <div className="space-y-4">
@@ -24,6 +27,7 @@ export default function ReviewStep() {
         </p>
 
         <div className="bg-gray-50 rounded-lg p-6 space-y-4 border border-gray-200">
+          {/* Basic Info */}
           <div>
             <h3 className="text-sm font-medium text-gray-500 uppercase tracking-wider">Basic Info</h3>
             <div className="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2">
@@ -42,14 +46,16 @@ export default function ReviewStep() {
             </div>
           </div>
 
+          {/* Parties */}
           <div className="border-t border-gray-200 pt-4">
             <h3 className="text-sm font-medium text-gray-500 uppercase tracking-wider">Parties</h3>
-            <div className="mt-2 text-wrap break-all">
+            <div className="mt-2">
               <span className="block text-xs text-gray-400">Counterparty Address</span>
               <span className="block text-sm text-gray-900 font-mono break-all">{values.counterpartyAddress}</span>
             </div>
           </div>
 
+          {/* Terms */}
           <div className="border-t border-gray-200 pt-4">
             <h3 className="text-sm font-medium text-gray-500 uppercase tracking-wider">Terms</h3>
             <div className="mt-2 grid grid-cols-1 gap-2 sm:grid-cols-2">
@@ -61,27 +67,59 @@ export default function ReviewStep() {
               </div>
               <div>
                 <span className="block text-xs text-gray-400">Deadline</span>
-                <span className="block text-sm text-gray-900 font-medium">{values.deadline ? formatDate(values.deadline) : '-'}</span>
+                <span className="block text-sm text-gray-900 font-medium">
+                  {values.deadline ? formatDate(values.deadline) : '-'}
+                </span>
               </div>
             </div>
           </div>
+
+          {/* Milestones */}
+          {milestones.length > 0 && (
+            <div className="border-t border-gray-200 pt-4">
+              <h3 className="text-sm font-medium text-gray-500 uppercase tracking-wider">Milestones</h3>
+              <ul className="mt-2 space-y-2">
+                {milestones.map((m, i) => (
+                  <li key={i} className="flex justify-between text-sm text-gray-700">
+                    <span>{m.description}</span>
+                    <span className="font-medium text-blue-600">{m.amount} XLM</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {/* Conditions */}
+          {conditions.length > 0 && (
+            <div className="border-t border-gray-200 pt-4">
+              <h3 className="text-sm font-medium text-gray-500 uppercase tracking-wider">Conditions</h3>
+              <ul className="mt-2 space-y-2">
+                {conditions.map((c, i) => (
+                  <li key={i} className="text-sm text-gray-700">
+                    <span className="font-medium capitalize">{c.type}</span>
+                    {c.description && ` — ${c.description}`}
+                    {c.releaseDate && (
+                      <span className="ml-1 text-gray-500 text-xs">({c.releaseDate})</span>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
         </div>
 
         <div className="rounded-md bg-yellow-50 p-4 border border-yellow-200">
           <div className="flex">
             <div className="flex-shrink-0">
-              {/* Warning Icon */}
               <svg className="h-5 w-5 text-yellow-400" viewBox="0 0 20 20" fill="currentColor">
                 <path fillRule="evenodd" d="M8.257 3.099c.765-1.36 2.722-1.36 3.486 0l5.58 9.92c.75 1.334-.213 2.98-1.742 2.98H4.42c-1.53 0-2.493-1.646-1.743-2.98l5.58-9.92zM11 13a1 1 0 11-2 0 1 1 0 012 0zm-1-8a1 1 0 00-1 1v3a1 1 0 002 0V6a1 1 0 00-1-1z" clipRule="evenodd" />
               </svg>
             </div>
             <div className="ml-3">
               <h3 className="text-sm font-medium text-yellow-800">Review carefully</h3>
-              <div className="mt-2 text-sm text-yellow-700">
-                <p>
-                  Once deployed on-chain, some parameters cannot be changed. Ensure the counterparty address is correct.
-                </p>
-              </div>
+              <p className="mt-2 text-sm text-yellow-700">
+                Once deployed on-chain, some parameters cannot be changed. Ensure the counterparty address is correct.
+              </p>
             </div>
           </div>
         </div>

--- a/apps/frontend/lib/escrow-schema.ts
+++ b/apps/frontend/lib/escrow-schema.ts
@@ -43,17 +43,17 @@ export const milestoneItemSchema = z.object({
 });
 
 export const milestonesSchema = z.object({
-  milestones: z.array(milestoneItemSchema).default([]),
+  milestones: z.array(milestoneItemSchema),
 });
 
 export const conditionItemSchema = z.object({
   type: z.enum(['manual', 'time', 'oracle']),
-  description: z.string().default(''),
-  releaseDate: z.string().default(''),
+  description: z.string().optional(),
+  releaseDate: z.string().optional(),
 });
 
 export const conditionsSchema = z.object({
-  conditions: z.array(conditionItemSchema).default([]),
+  conditions: z.array(conditionItemSchema),
 });
 
 // Combined schema for the full form state

--- a/apps/frontend/lib/escrow-schema.ts
+++ b/apps/frontend/lib/escrow-schema.ts
@@ -34,12 +34,38 @@ export const termsSchema = z.object({
   }),
 });
 
+export const milestoneItemSchema = z.object({
+  description: z.string().min(3, 'Description must be at least 3 characters'),
+  amount: z.string().refine((val) => {
+    const num = parseFloat(val);
+    return !isNaN(num) && num > 0;
+  }, { message: 'Amount must be a positive number' }),
+});
+
+export const milestonesSchema = z.object({
+  milestones: z.array(milestoneItemSchema).optional().default([]),
+});
+
+export const conditionItemSchema = z.object({
+  type: z.enum(['manual', 'time', 'oracle']),
+  description: z.string().optional().default(''),
+  releaseDate: z.string().optional().default(''),
+});
+
+export const conditionsSchema = z.object({
+  conditions: z.array(conditionItemSchema).optional().default([]),
+});
+
 // Combined schema for the full form state
 export const createEscrowSchema = basicInfoSchema
   .merge(partiesSchema)
-  .merge(termsSchema);
+  .merge(termsSchema)
+  .merge(milestonesSchema)
+  .merge(conditionsSchema);
 
 export type CreateEscrowFormData = z.infer<typeof createEscrowSchema>;
 export type BasicInfoFormData = z.infer<typeof basicInfoSchema>;
 export type PartiesFormData = z.infer<typeof partiesSchema>;
 export type TermsFormData = z.infer<typeof termsSchema>;
+export type MilestoneItem = z.infer<typeof milestoneItemSchema>;
+export type ConditionItem = z.infer<typeof conditionItemSchema>;

--- a/apps/frontend/lib/escrow-schema.ts
+++ b/apps/frontend/lib/escrow-schema.ts
@@ -43,17 +43,17 @@ export const milestoneItemSchema = z.object({
 });
 
 export const milestonesSchema = z.object({
-  milestones: z.array(milestoneItemSchema).optional().default([]),
+  milestones: z.array(milestoneItemSchema).default([]),
 });
 
 export const conditionItemSchema = z.object({
   type: z.enum(['manual', 'time', 'oracle']),
-  description: z.string().optional().default(''),
-  releaseDate: z.string().optional().default(''),
+  description: z.string().default(''),
+  releaseDate: z.string().default(''),
 });
 
 export const conditionsSchema = z.object({
-  conditions: z.array(conditionItemSchema).optional().default([]),
+  conditions: z.array(conditionItemSchema).default([]),
 });
 
 // Combined schema for the full form state


### PR DESCRIPTION
## Summary

- Added `MilestonesStep` — dynamic add/remove milestone fields with description and amount inputs
- Added `ConditionsStep` — supports manual, time-based, and oracle release conditions; time-based condition reveals a datetime picker
- Extended `escrow-schema.ts` with `milestonesSchema` and `conditionsSchema` (both optional, default to empty arrays)
- Updated `CreateEscrowWizard` from 4 to 6 steps: Basic Info → Parties → Terms → Milestones → Conditions → Review
- Updated `ReviewStep` to display added milestones and conditions in the summary card

## Test plan

- [ ] Wizard stepper shows 6 steps with correct labels
- [ ] Navigating forward/backward preserves all field values
- [ ] Milestones step allows adding and removing milestone items
- [ ] Conditions step allows adding manual, time-based (shows date picker), and oracle conditions
- [ ] Review step summarises milestones and conditions
- [ ] Form submits successfully with 0 or more milestones/conditions

Closes #188