### PR TITLE
feat(backend): add URI versioning and per-user rate limiting

### DIFF
--- a/apps/backend/src/api-key/api-key.module.ts
+++ b/apps/backend/src/api-key/api-key.module.ts
@@ -3,11 +3,13 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { ApiKeysService } from './api-key.service';
 import { ApiKeyController } from './api-key.controller';
 import { ApiKey } from './entities/api-key.entity';
+import { ApiRateLimitService } from './api-rate-limit.service';
+import { ApiKeyGuard } from './guards/api-key.guard';
 
 @Module({
   imports: [TypeOrmModule.forFeature([ApiKey])],
   controllers: [ApiKeyController],
-  providers: [ApiKeysService],
-  exports: [ApiKeysService],
+  providers: [ApiKeysService, ApiRateLimitService, ApiKeyGuard],
+  exports: [ApiKeysService, ApiRateLimitService, ApiKeyGuard],
 })
 export class ApiKeyModule {}

--- a/apps/backend/src/api-key/api-rate-limit.service.ts
+++ b/apps/backend/src/api-key/api-rate-limit.service.ts
@@ -1,27 +1,43 @@
-import { Injectable, RequestTimeoutException } from '@nestjs/common';
+import { Injectable, HttpException, HttpStatus } from '@nestjs/common';
+
+interface RateLimitRecord {
+  count: number;
+  resetAt: number;
+}
+
+export interface RateLimitInfo {
+  limit: number;
+  remaining: number;
+  resetAt: number;
+}
 
 @Injectable()
 export class ApiRateLimitService {
-  private usage = new Map<string, { count: number; resetAt: number }>();
+  private readonly usage = new Map<string, RateLimitRecord>();
+  private readonly windowMs = 60 * 1000;
 
-  check(keyId: string, limit: number) {
+  check(keyId: string, limit: number): RateLimitInfo {
     const now = Date.now();
-    const windowMs = 60 * 1000;
-
     const record = this.usage.get(keyId);
 
     if (!record || now > record.resetAt) {
-      this.usage.set(keyId, {
-        count: 1,
-        resetAt: now + windowMs,
-      });
-      return;
+      const resetAt = now + this.windowMs;
+      this.usage.set(keyId, { count: 1, resetAt });
+      return { limit, remaining: limit - 1, resetAt };
     }
 
     if (record.count >= limit) {
-      throw new RequestTimeoutException('Rate limit exceeded');
+      throw new HttpException(
+        {
+          statusCode: HttpStatus.TOO_MANY_REQUESTS,
+          message: 'Rate limit exceeded. Please retry after the reset window.',
+          retryAfter: Math.ceil((record.resetAt - now) / 1000),
+        },
+        HttpStatus.TOO_MANY_REQUESTS,
+      );
     }
 
     record.count++;
+    return { limit, remaining: limit - record.count, resetAt: record.resetAt };
   }
 }

--- a/apps/backend/src/api-key/entities/api-key.entity.ts
+++ b/apps/backend/src/api-key/entities/api-key.entity.ts
@@ -5,6 +5,19 @@ import {
   CreateDateColumn,
 } from 'typeorm';
 
+export enum ApiKeyTier {
+  NONE = 'none',
+  FREE = 'free',
+  PRO = 'pro',
+}
+
+// Rate limits per tier (requests per minute)
+export const TIER_LIMITS: Record<ApiKeyTier, number> = {
+  [ApiKeyTier.NONE]: 60,
+  [ApiKeyTier.FREE]: 120,
+  [ApiKeyTier.PRO]: 600,
+};
+
 @Entity()
 export class ApiKey {
   @PrimaryGeneratedColumn('uuid')
@@ -14,7 +27,7 @@ export class ApiKey {
   name: string;
 
   @Column({ unique: true })
-  keyHash: string; // store hashed version only
+  keyHash: string;
 
   @Column()
   ownerUserId: string;
@@ -25,7 +38,10 @@ export class ApiKey {
   @Column({ nullable: true })
   revokedAt?: Date;
 
-  @Column({ type: 'int', default: 60 })
+  @Column({ type: 'text', default: ApiKeyTier.FREE })
+  tier: ApiKeyTier;
+
+  @Column({ type: 'int', default: 120 })
   rateLimitPerMinute: number;
 
   @CreateDateColumn()

--- a/apps/backend/src/api-key/guards/api-key.guard.ts
+++ b/apps/backend/src/api-key/guards/api-key.guard.ts
@@ -5,19 +5,26 @@ import {
   UnauthorizedException,
   ForbiddenException,
 } from '@nestjs/common';
-import { Request } from 'express';
+import { Request, Response } from 'express';
 import { ApiKeysService } from '../api-key.service';
+import { ApiRateLimitService } from '../api-rate-limit.service';
+import { ApiKey, TIER_LIMITS } from '../entities/api-key.entity';
 
 interface RequestWithApiKey extends Request {
-  apiKey?: unknown;
+  apiKey?: ApiKey;
 }
 
 @Injectable()
 export class ApiKeyGuard implements CanActivate {
-  constructor(private apiKeyService: ApiKeysService) {}
+  constructor(
+    private apiKeyService: ApiKeysService,
+    private rateLimitService: ApiRateLimitService,
+  ) {}
 
   async canActivate(context: ExecutionContext): Promise<boolean> {
-    const req = context.switchToHttp().getRequest<RequestWithApiKey>();
+    const http = context.switchToHttp();
+    const req = http.getRequest<RequestWithApiKey>();
+    const res = http.getResponse<Response>();
 
     const rawKey = req.header('X-API-Key');
     if (!rawKey) {
@@ -33,6 +40,13 @@ export class ApiKeyGuard implements CanActivate {
     if (!key.active) {
       throw new ForbiddenException('API key revoked');
     }
+
+    const limit = TIER_LIMITS[key.tier] ?? key.rateLimitPerMinute;
+    const info = this.rateLimitService.check(key.id, limit);
+
+    res.setHeader('X-RateLimit-Limit', info.limit);
+    res.setHeader('X-RateLimit-Remaining', info.remaining);
+    res.setHeader('X-RateLimit-Reset', Math.ceil(info.resetAt / 1000));
 
     req.apiKey = key;
     return true;

--- a/apps/backend/src/main.ts
+++ b/apps/backend/src/main.ts
@@ -1,10 +1,16 @@
 import { NestFactory } from '@nestjs/core';
-import { ValidationPipe } from '@nestjs/common';
+import { ValidationPipe, VersioningType } from '@nestjs/common';
 import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 import { AppModule } from './app.module';
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule);
+
+  // URI versioning — all routes become /v1/...
+  app.enableVersioning({
+    type: VersioningType.URI,
+    defaultVersion: '1',
+  });
 
   // Enable global validation
   app.useGlobalPipes(


### PR DESCRIPTION
## Summary

- Enabled NestJS URI versioning (`VersioningType.URI`, `defaultVersion: '1'`) in `main.ts` — all routes now resolve under `/v1/`
- Added `tier` field (`none | free | pro`) to the `ApiKey` entity with corresponding rate limits: none = 60 req/min, free = 120 req/min, pro = 600 req/min
- Updated `ApiRateLimitService` to return `RateLimitInfo` (limit, remaining, resetAt) and throw HTTP 429 with a `retryAfter` field on limit exceeded
- Updated `ApiKeyGuard` to enforce per-user rate limits based on the key's tier and attach `X-RateLimit-Limit`, `X-RateLimit-Remaining`, `X-RateLimit-Reset` headers to every response
- Registered `ApiRateLimitService` and `ApiKeyGuard` in `ApiKeyModule`

## Test plan

- [ ] All API routes respond under `/v1/` prefix
- [ ] Requests with a valid API key include `X-RateLimit-*` headers
- [ ] Exceeding the rate limit returns HTTP 429 with a `retryAfter` value
- [ ] Pro-tier keys allow up to 600 req/min; free-tier allows 120; no-key allows 60
- [ ] Rate limit window resets after 60 seconds

Closes #205