### PR TITLE
[CONTRACT] Metadata hash usage: validation and interop (IPFS/CID stra…

### DIFF
--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -84,7 +84,9 @@ import ipfsConfig from './config/ipfs.config';
     IpfsModule,
     JwtModule.registerAsync({
       useFactory: (configService: ConfigService) => ({
-        secret: configService.get<string>('JWT_SECRET') || 'your-secret-key-change-in-production',
+        secret:
+          configService.get<string>('JWT_SECRET') ||
+          'your-secret-key-change-in-production',
         signOptions: { expiresIn: '15m' },
       }),
       inject: [ConfigService],

--- a/apps/backend/src/gateways/escrow.gateway.ts
+++ b/apps/backend/src/gateways/escrow.gateway.ts
@@ -39,16 +39,16 @@ export class EscrowGateway implements OnGatewayConnection, OnGatewayDisconnect {
         (client.handshake.headers.authorization as string)?.split(' ')[1];
 
       if (!token) {
-        this.logger.warn(`Connection rejected: No token provided (${client.id})`);
+        this.logger.warn(
+          `Connection rejected: No token provided (${client.id})`,
+        );
         client.disconnect();
         return;
       }
 
       // Verify JWT
-      const decoded: { sub?: string; userId?: string } = this.jwtService.verify(token) as {
-        sub?: string;
-        userId?: string;
-      };
+      const decoded: { sub?: string; userId?: string } =
+        this.jwtService.verify(token);
       const userId: string | undefined = decoded?.sub || decoded?.userId;
 
       if (!userId) {
@@ -68,7 +68,10 @@ export class EscrowGateway implements OnGatewayConnection, OnGatewayDisconnect {
       // Send connection success
       client.emit('connected', { userId, socketId: client.id });
     } catch (error: unknown) {
-      this.logger.error(`Connection rejected: Invalid token (${client.id})`, error);
+      this.logger.error(
+        `Connection rejected: Invalid token (${client.id})`,
+        error,
+      );
       client.disconnect();
     }
   }

--- a/apps/backend/src/modules/escrow/services/escrow-stellar-integration.service.spec.ts
+++ b/apps/backend/src/modules/escrow/services/escrow-stellar-integration.service.spec.ts
@@ -77,6 +77,7 @@ describe('EscrowStellarIntegrationService', () => {
     assetCode: 'XLM',
     assetIssuer: null,
     expiresAt: new Date(),
+    metadataHash: '0'.repeat(64),
   };
 
   describe('createOnChainEscrow', () => {

--- a/apps/backend/src/modules/escrow/services/escrow-stellar-integration.service.ts
+++ b/apps/backend/src/modules/escrow/services/escrow-stellar-integration.service.ts
@@ -50,6 +50,12 @@ export class EscrowStellarIntegrationService {
         throw new Error(`Escrow with ID ${escrowId} not found`);
       }
 
+      if (!escrow.metadataHash) {
+        throw new Error(
+          `Escrow ${escrowId} is missing metadataHash for on-chain creation`,
+        );
+      }
+
       // Get the depositor (usually the buyer)
       const depositor = escrow.parties.find(
         (party) => party.role === ('buyer' as any),
@@ -91,6 +97,7 @@ export class EscrowStellarIntegrationService {
           escrow.expiresAt
             ? Math.floor(new Date(escrow.expiresAt).getTime() / 1000)
             : Math.floor(Date.now() / 1000) + 86400, // Convert to Unix timestamp or default to 24 hours
+          escrow.metadataHash,
         );
 
       // Build the transaction

--- a/apps/backend/src/modules/escrow/services/escrow.service.spec.ts
+++ b/apps/backend/src/modules/escrow/services/escrow.service.spec.ts
@@ -223,6 +223,46 @@ describe('EscrowService', () => {
       expect(result).toBeDefined();
       expect(conditionRepository.save.mock.calls.length).toBeGreaterThan(0);
     });
+
+    it('should normalize metadataHash before persisting', async () => {
+      const createDto: CreateEscrowDto = {
+        title: 'Test Escrow',
+        amount: 100,
+        parties: [{ userId: 'user-456', role: PartyRole.SELLER }],
+        metadataHash:
+          '0102030405060708090A0B0C0D0E0F101112131415161718191A1B1C1D1E1F20',
+      };
+
+      escrowRepository.create.mockReturnValue(mockEscrow as Escrow);
+      escrowRepository.save.mockResolvedValue(mockEscrow as Escrow);
+      escrowRepository.findOne.mockResolvedValue(mockEscrow as Escrow);
+      partyRepository.create.mockReturnValue(mockParty as Party);
+      partyRepository.save.mockResolvedValue(mockParty as Party);
+      eventRepository.create.mockReturnValue({} as EscrowEvent);
+      eventRepository.save.mockResolvedValue({} as EscrowEvent);
+
+      await service.create(createDto, 'user-123');
+
+      expect(escrowRepository.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          metadataHash:
+            '0102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f20',
+        }),
+      );
+    });
+
+    it('should reject malformed metadataHash values', async () => {
+      const createDto: CreateEscrowDto = {
+        title: 'Test Escrow',
+        amount: 100,
+        parties: [{ userId: 'user-456', role: PartyRole.SELLER }],
+        metadataHash: 'not-a-cid',
+      };
+
+      await expect(service.create(createDto, 'user-123')).rejects.toThrow(
+        BadRequestException,
+      );
+    });
   });
 
   describe('findOne', () => {

--- a/apps/backend/src/modules/escrow/services/escrow.service.ts
+++ b/apps/backend/src/modules/escrow/services/escrow.service.ts
@@ -1287,4 +1287,17 @@ export class EscrowService {
       url: this.ipfsService.getGatewayUrl(cid),
     };
   }
+
+  private getErrorMessage(error: unknown): string {
+    if (error instanceof Error) {
+      return error.message;
+    }
+
+    if (typeof error === 'object' && error !== null && 'message' in error) {
+      const message = (error as { message?: unknown }).message;
+      return typeof message === 'string' ? message : String(message);
+    }
+
+    return 'Unknown error';
+  }
 }

--- a/apps/backend/src/modules/escrow/services/escrow.service.ts
+++ b/apps/backend/src/modules/escrow/services/escrow.service.ts
@@ -42,6 +42,7 @@ import { WebhookService } from '../../../services/webhook/webhook.service';
 import { User, UserRole } from '../../user/entities/user.entity';
 import { IpfsService } from '../../ipfs/ipfs.service';
 import { AllowedAsset } from '../../assets/entities/allowed-asset.entity';
+import { normalizeMetadataHash } from '../utils/metadata-hash.util';
 
 @Injectable()
 export class EscrowService {
@@ -71,6 +72,17 @@ export class EscrowService {
     creatorId: string,
     ipAddress?: string,
   ): Promise<Escrow> {
+    let metadataHash: string | undefined;
+    if (dto.metadataHash) {
+      try {
+        metadataHash = normalizeMetadataHash(dto.metadataHash);
+      } catch (error) {
+        throw new BadRequestException(
+          `Invalid metadataHash: ${this.getErrorMessage(error)}`,
+        );
+      }
+    }
+
     const escrow = this.escrowRepository.create({
       title: dto.title,
       description: dto.description,
@@ -80,7 +92,7 @@ export class EscrowService {
       type: dto.type,
       creatorId,
       expiresAt: dto.expiresAt ? new Date(dto.expiresAt) : undefined,
-      metadataHash: dto.metadataHash,
+      metadataHash,
     } as Partial<Escrow>);
 
     const savedEscrow = (await this.escrowRepository.save(

--- a/apps/backend/src/modules/escrow/utils/metadata-hash.util.spec.ts
+++ b/apps/backend/src/modules/escrow/utils/metadata-hash.util.spec.ts
@@ -1,0 +1,94 @@
+import { normalizeMetadataHash } from './metadata-hash.util';
+
+const BASE32_ALPHABET = 'abcdefghijklmnopqrstuvwxyz234567';
+const BASE58BTC_ALPHABET =
+  '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
+describe('normalizeMetadataHash', () => {
+  const digest = Uint8Array.from(
+    Array.from({ length: 32 }, (_, index) => index + 1),
+  );
+  const digestHex = Array.from(digest, (byte) =>
+    byte.toString(16).padStart(2, '0'),
+  ).join('');
+
+  it('normalizes raw hex digests', () => {
+    expect(normalizeMetadataHash(digestHex.toUpperCase())).toBe(digestHex);
+  });
+
+  it('normalizes cidv1 base32 references', () => {
+    const cid = `b${encodeBase32(
+      Uint8Array.from([0x01, 0x55, 0x12, 0x20, ...digest]),
+    )}`;
+
+    expect(normalizeMetadataHash(`ipfs://${cid}`)).toBe(digestHex);
+  });
+
+  it('normalizes cidv0 base58 references', () => {
+    const cid = encodeBase58(Uint8Array.from([0x12, 0x20, ...digest]));
+
+    expect(normalizeMetadataHash(cid)).toBe(digestHex);
+  });
+
+  it('rejects non-sha256 multihashes', () => {
+    const cid = `b${encodeBase32(
+      Uint8Array.from([0x01, 0x55, 0x13, 0x20, ...digest]),
+    )}`;
+
+    expect(() => normalizeMetadataHash(cid)).toThrow('sha2-256');
+  });
+});
+
+function encodeBase32(bytes: Uint8Array): string {
+  let bits = 0;
+  let bitCount = 0;
+  let output = '';
+
+  for (const byte of bytes) {
+    bits = (bits << 8) | byte;
+    bitCount += 8;
+
+    while (bitCount >= 5) {
+      bitCount -= 5;
+      output += BASE32_ALPHABET[(bits >> bitCount) & 31];
+    }
+  }
+
+  if (bitCount > 0) {
+    output += BASE32_ALPHABET[(bits << (5 - bitCount)) & 31];
+  }
+
+  return output;
+}
+
+function encodeBase58(bytes: Uint8Array): string {
+  if (bytes.length === 0) {
+    return '';
+  }
+
+  const digits = [0];
+  for (const byte of bytes) {
+    let carry = byte;
+    for (let i = 0; i < digits.length; i += 1) {
+      const next = digits[i] * 256 + carry;
+      digits[i] = next % 58;
+      carry = Math.floor(next / 58);
+    }
+
+    while (carry > 0) {
+      digits.push(carry % 58);
+      carry = Math.floor(carry / 58);
+    }
+  }
+
+  let output = '';
+  for (let i = 0; i < bytes.length && bytes[i] === 0; i += 1) {
+    output += BASE58BTC_ALPHABET[0];
+  }
+
+  for (let i = digits.length - 1; i >= 0; i -= 1) {
+    output += BASE58BTC_ALPHABET[digits[i]];
+  }
+
+  return output;
+}

--- a/apps/backend/src/modules/escrow/utils/metadata-hash.util.ts
+++ b/apps/backend/src/modules/escrow/utils/metadata-hash.util.ts
@@ -24,6 +24,9 @@ export function normalizeMetadataHash(reference: string): string {
 }
 
 function sanitizeReference(reference: string): string {
+  if (!reference) {
+    throw new Error('metadata hash is required');
+  }
   const value = reference.trim();
   if (!value) {
     throw new Error('metadata hash is required');

--- a/apps/backend/src/modules/escrow/utils/metadata-hash.util.ts
+++ b/apps/backend/src/modules/escrow/utils/metadata-hash.util.ts
@@ -179,7 +179,11 @@ function decodeBase58(value: string): Uint8Array {
     }
   }
 
-  for (let i = 0; i < value.length && value[i] === BASE58BTC_ALPHABET[0]; i += 1) {
+  for (
+    let i = 0;
+    i < value.length && value[i] === BASE58BTC_ALPHABET[0];
+    i += 1
+  ) {
     bytes.push(0);
   }
 

--- a/apps/backend/src/modules/escrow/utils/metadata-hash.util.ts
+++ b/apps/backend/src/modules/escrow/utils/metadata-hash.util.ts
@@ -1,0 +1,194 @@
+const SHA256_MULTIHASH_CODE = 0x12;
+const SHA256_DIGEST_LENGTH = 32;
+const CID_V1 = 1;
+
+const BASE32_ALPHABET = 'abcdefghijklmnopqrstuvwxyz234567';
+const BASE58BTC_ALPHABET =
+  '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+const HEX_32_RE = /^[0-9a-f]{64}$/;
+
+export function normalizeMetadataHash(reference: string): string {
+  const value = sanitizeReference(reference);
+  const lowered = value.toLowerCase();
+
+  if (HEX_32_RE.test(lowered)) {
+    return lowered;
+  }
+
+  const cid = extractCid(value);
+  const digest = cid.startsWith('Qm')
+    ? extractDigestFromCidV0(cid)
+    : extractDigestFromCidV1(cid);
+
+  return bytesToHex(digest);
+}
+
+function sanitizeReference(reference: string): string {
+  const value = reference.trim();
+  if (!value) {
+    throw new Error('metadata hash is required');
+  }
+
+  return value;
+}
+
+function extractCid(reference: string): string {
+  if (!reference.toLowerCase().startsWith('ipfs://')) {
+    return reference;
+  }
+
+  const withoutScheme = reference.slice('ipfs://'.length);
+  const cid = withoutScheme.split(/[/?#]/, 1)[0];
+  if (!cid) {
+    throw new Error('invalid ipfs reference');
+  }
+
+  return cid;
+}
+
+function extractDigestFromCidV0(cid: string): Uint8Array {
+  return parseMultihash(decodeBase58(cid));
+}
+
+function extractDigestFromCidV1(cid: string): Uint8Array {
+  const multibase = cid[0];
+  const payload = cid.slice(1);
+
+  if (!payload) {
+    throw new Error('invalid cid');
+  }
+
+  let decoded: Uint8Array;
+  if (multibase === 'b' || multibase === 'B') {
+    decoded = decodeBase32(payload.toLowerCase());
+  } else if (multibase === 'z') {
+    decoded = decodeBase58(payload);
+  } else {
+    throw new Error('unsupported cid multibase');
+  }
+
+  let offset = 0;
+  const version = readVarint(decoded, offset);
+  offset = version.nextOffset;
+  if (version.value !== CID_V1) {
+    throw new Error('unsupported cid version');
+  }
+
+  const codec = readVarint(decoded, offset);
+  offset = codec.nextOffset;
+  void codec;
+
+  return parseMultihash(decoded.slice(offset));
+}
+
+function parseMultihash(bytes: Uint8Array): Uint8Array {
+  let offset = 0;
+  const code = readVarint(bytes, offset);
+  offset = code.nextOffset;
+  const length = readVarint(bytes, offset);
+  offset = length.nextOffset;
+
+  if (code.value !== SHA256_MULTIHASH_CODE) {
+    throw new Error('metadata hash must use sha2-256');
+  }
+
+  if (length.value !== SHA256_DIGEST_LENGTH) {
+    throw new Error('metadata hash digest must be 32 bytes');
+  }
+
+  const digest = bytes.slice(offset, offset + length.value);
+  if (digest.length !== SHA256_DIGEST_LENGTH) {
+    throw new Error('metadata hash digest is truncated');
+  }
+
+  if (offset + length.value !== bytes.length) {
+    throw new Error('invalid multihash length');
+  }
+
+  return digest;
+}
+
+function readVarint(
+  bytes: Uint8Array,
+  offset: number,
+): { value: number; nextOffset: number } {
+  let value = 0;
+  let shift = 0;
+  let index = offset;
+
+  while (index < bytes.length) {
+    const current = bytes[index];
+    value |= (current & 0x7f) << shift;
+    index += 1;
+
+    if ((current & 0x80) === 0) {
+      return { value, nextOffset: index };
+    }
+
+    shift += 7;
+    if (shift > 28) {
+      throw new Error('varint is too large');
+    }
+  }
+
+  throw new Error('unexpected end of varint');
+}
+
+function decodeBase32(value: string): Uint8Array {
+  let bits = 0;
+  let bitCount = 0;
+  const bytes: number[] = [];
+
+  for (const char of value) {
+    const index = BASE32_ALPHABET.indexOf(char);
+    if (index === -1) {
+      throw new Error('invalid base32 cid');
+    }
+
+    bits = (bits << 5) | index;
+    bitCount += 5;
+
+    while (bitCount >= 8) {
+      bitCount -= 8;
+      bytes.push((bits >> bitCount) & 0xff);
+    }
+  }
+
+  return Uint8Array.from(bytes);
+}
+
+function decodeBase58(value: string): Uint8Array {
+  const bytes: number[] = [0];
+
+  for (const char of value) {
+    const carryIndex = BASE58BTC_ALPHABET.indexOf(char);
+    if (carryIndex === -1) {
+      throw new Error('invalid base58 cid');
+    }
+
+    let carry = carryIndex;
+    for (let i = 0; i < bytes.length; i += 1) {
+      const next = bytes[i] * 58 + carry;
+      bytes[i] = next & 0xff;
+      carry = next >> 8;
+    }
+
+    while (carry > 0) {
+      bytes.push(carry & 0xff);
+      carry >>= 8;
+    }
+  }
+
+  for (let i = 0; i < value.length && value[i] === BASE58BTC_ALPHABET[0]; i += 1) {
+    bytes.push(0);
+  }
+
+  bytes.reverse();
+  return Uint8Array.from(bytes);
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join(
+    '',
+  );
+}

--- a/apps/backend/src/services/stellar.service.ts
+++ b/apps/backend/src/services/stellar.service.ts
@@ -180,7 +180,8 @@ export class StellarService {
     this.logger.log(`Starting transaction stream for account: ${accountId}`);
 
     const handler = (transaction: any) => {
-      const typedTransaction = transaction as unknown as StellarTransactionResponse;
+      const typedTransaction =
+        transaction as unknown as StellarTransactionResponse;
       this.logger.log(
         `Received transaction: ${typedTransaction.id} for account: ${accountId}`,
       );

--- a/apps/backend/src/services/stellar/escrow-operations.ts
+++ b/apps/backend/src/services/stellar/escrow-operations.ts
@@ -1,5 +1,6 @@
 import * as StellarSdk from '@stellar/stellar-sdk';
 import { Injectable, Logger } from '@nestjs/common';
+import { normalizeMetadataHash } from '../../modules/escrow/utils/metadata-hash.util';
 
 @Injectable()
 export class EscrowOperationsService {
@@ -21,6 +22,7 @@ export class EscrowOperationsService {
     tokenAddress: string,
     milestones: Array<{ id: number; amount: string; description: string }>,
     deadline: number,
+    metadataReference: string,
   ): StellarSdk.xdr.Operation[] {
     try {
       this.logger.log(
@@ -28,6 +30,10 @@ export class EscrowOperationsService {
       );
 
       const contract = new StellarSdk.Contract(this.contractId);
+      const metadataHash = Buffer.from(
+        normalizeMetadataHash(metadataReference),
+        'hex',
+      );
 
       const milestoneVec = StellarSdk.xdr.ScVal.scvVec(
         milestones.map((m) =>
@@ -69,6 +75,7 @@ export class EscrowOperationsService {
         StellarSdk.xdr.ScVal.scvU64(
           new StellarSdk.xdr.Uint64(deadline.toString()),
         ),
+        StellarSdk.xdr.ScVal.scvBytes(metadataHash),
       );
 
       return [op];

--- a/apps/backend/src/services/stellar/soroban-integration.spec.ts
+++ b/apps/backend/src/services/stellar/soroban-integration.spec.ts
@@ -34,6 +34,7 @@ describe('EscrowOperationsService Integration', () => {
       token,
       milestones,
       deadline,
+      '0'.repeat(64), // Valid hex metadata hash
     );
 
     const op = ops[0] as any as {

--- a/apps/frontend/lib/metadata-hash.test.ts
+++ b/apps/frontend/lib/metadata-hash.test.ts
@@ -1,0 +1,94 @@
+import { normalizeMetadataHash } from '@/lib/metadata-hash';
+
+const BASE32_ALPHABET = 'abcdefghijklmnopqrstuvwxyz234567';
+const BASE58BTC_ALPHABET =
+  '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+
+describe('normalizeMetadataHash', () => {
+  const digest = Uint8Array.from(
+    Array.from({ length: 32 }, (_, index) => index + 1),
+  );
+  const digestHex = Array.from(digest, (byte) =>
+    byte.toString(16).padStart(2, '0'),
+  ).join('');
+
+  it('normalizes raw hex digests', () => {
+    expect(normalizeMetadataHash(digestHex.toUpperCase())).toBe(digestHex);
+  });
+
+  it('normalizes cidv1 base32 references', () => {
+    const cid = `b${encodeBase32(
+      Uint8Array.from([0x01, 0x55, 0x12, 0x20, ...digest]),
+    )}`;
+
+    expect(normalizeMetadataHash(`ipfs://${cid}`)).toBe(digestHex);
+  });
+
+  it('normalizes cidv0 base58 references', () => {
+    const cid = encodeBase58(Uint8Array.from([0x12, 0x20, ...digest]));
+
+    expect(normalizeMetadataHash(cid)).toBe(digestHex);
+  });
+
+  it('rejects non-sha256 multihashes', () => {
+    const cid = `b${encodeBase32(
+      Uint8Array.from([0x01, 0x55, 0x13, 0x20, ...digest]),
+    )}`;
+
+    expect(() => normalizeMetadataHash(cid)).toThrow('sha2-256');
+  });
+});
+
+function encodeBase32(bytes: Uint8Array): string {
+  let bits = 0;
+  let bitCount = 0;
+  let output = '';
+
+  for (const byte of bytes) {
+    bits = (bits << 8) | byte;
+    bitCount += 8;
+
+    while (bitCount >= 5) {
+      bitCount -= 5;
+      output += BASE32_ALPHABET[(bits >> bitCount) & 31];
+    }
+  }
+
+  if (bitCount > 0) {
+    output += BASE32_ALPHABET[(bits << (5 - bitCount)) & 31];
+  }
+
+  return output;
+}
+
+function encodeBase58(bytes: Uint8Array): string {
+  if (bytes.length === 0) {
+    return '';
+  }
+
+  const digits = [0];
+  for (const byte of bytes) {
+    let carry = byte;
+    for (let i = 0; i < digits.length; i += 1) {
+      const next = digits[i] * 256 + carry;
+      digits[i] = next % 58;
+      carry = Math.floor(next / 58);
+    }
+
+    while (carry > 0) {
+      digits.push(carry % 58);
+      carry = Math.floor(carry / 58);
+    }
+  }
+
+  let output = '';
+  for (let i = 0; i < bytes.length && bytes[i] === 0; i += 1) {
+    output += BASE58BTC_ALPHABET[0];
+  }
+
+  for (let i = digits.length - 1; i >= 0; i -= 1) {
+    output += BASE58BTC_ALPHABET[digits[i]];
+  }
+
+  return output;
+}

--- a/apps/frontend/lib/metadata-hash.ts
+++ b/apps/frontend/lib/metadata-hash.ts
@@ -1,0 +1,194 @@
+const SHA256_MULTIHASH_CODE = 0x12;
+const SHA256_DIGEST_LENGTH = 32;
+const CID_V1 = 1;
+
+const BASE32_ALPHABET = 'abcdefghijklmnopqrstuvwxyz234567';
+const BASE58BTC_ALPHABET =
+  '123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz';
+const HEX_32_RE = /^[0-9a-f]{64}$/;
+
+export function normalizeMetadataHash(reference: string): string {
+  const value = sanitizeReference(reference);
+  const lowered = value.toLowerCase();
+
+  if (HEX_32_RE.test(lowered)) {
+    return lowered;
+  }
+
+  const cid = extractCid(value);
+  const digest = cid.startsWith('Qm')
+    ? extractDigestFromCidV0(cid)
+    : extractDigestFromCidV1(cid);
+
+  return bytesToHex(digest);
+}
+
+function sanitizeReference(reference: string): string {
+  const value = reference.trim();
+  if (!value) {
+    throw new Error('metadata hash is required');
+  }
+
+  return value;
+}
+
+function extractCid(reference: string): string {
+  if (!reference.toLowerCase().startsWith('ipfs://')) {
+    return reference;
+  }
+
+  const withoutScheme = reference.slice('ipfs://'.length);
+  const cid = withoutScheme.split(/[/?#]/, 1)[0];
+  if (!cid) {
+    throw new Error('invalid ipfs reference');
+  }
+
+  return cid;
+}
+
+function extractDigestFromCidV0(cid: string): Uint8Array {
+  return parseMultihash(decodeBase58(cid));
+}
+
+function extractDigestFromCidV1(cid: string): Uint8Array {
+  const multibase = cid[0];
+  const payload = cid.slice(1);
+
+  if (!payload) {
+    throw new Error('invalid cid');
+  }
+
+  const decoded =
+    multibase === 'b' || multibase === 'B'
+      ? decodeBase32(payload.toLowerCase())
+      : multibase === 'z'
+        ? decodeBase58(payload)
+        : (() => {
+            throw new Error('unsupported cid multibase');
+          })();
+
+  let offset = 0;
+  const version = readVarint(decoded, offset);
+  offset = version.nextOffset;
+  if (version.value !== CID_V1) {
+    throw new Error('unsupported cid version');
+  }
+
+  const codec = readVarint(decoded, offset);
+  offset = codec.nextOffset;
+  void codec;
+
+  return parseMultihash(decoded.slice(offset));
+}
+
+function parseMultihash(bytes: Uint8Array): Uint8Array {
+  let offset = 0;
+  const code = readVarint(bytes, offset);
+  offset = code.nextOffset;
+  const length = readVarint(bytes, offset);
+  offset = length.nextOffset;
+
+  if (code.value !== SHA256_MULTIHASH_CODE) {
+    throw new Error('metadata hash must use sha2-256');
+  }
+
+  if (length.value !== SHA256_DIGEST_LENGTH) {
+    throw new Error('metadata hash digest must be 32 bytes');
+  }
+
+  const digest = bytes.slice(offset, offset + length.value);
+  if (digest.length !== SHA256_DIGEST_LENGTH) {
+    throw new Error('metadata hash digest is truncated');
+  }
+
+  if (offset + length.value !== bytes.length) {
+    throw new Error('invalid multihash length');
+  }
+
+  return digest;
+}
+
+function readVarint(
+  bytes: Uint8Array,
+  offset: number,
+): { value: number; nextOffset: number } {
+  let value = 0;
+  let shift = 0;
+  let index = offset;
+
+  while (index < bytes.length) {
+    const current = bytes[index];
+    value |= (current & 0x7f) << shift;
+    index += 1;
+
+    if ((current & 0x80) === 0) {
+      return { value, nextOffset: index };
+    }
+
+    shift += 7;
+    if (shift > 28) {
+      throw new Error('varint is too large');
+    }
+  }
+
+  throw new Error('unexpected end of varint');
+}
+
+function decodeBase32(value: string): Uint8Array {
+  let bits = 0;
+  let bitCount = 0;
+  const bytes: number[] = [];
+
+  for (const char of value) {
+    const index = BASE32_ALPHABET.indexOf(char);
+    if (index === -1) {
+      throw new Error('invalid base32 cid');
+    }
+
+    bits = (bits << 5) | index;
+    bitCount += 5;
+
+    while (bitCount >= 8) {
+      bitCount -= 8;
+      bytes.push((bits >> bitCount) & 0xff);
+    }
+  }
+
+  return Uint8Array.from(bytes);
+}
+
+function decodeBase58(value: string): Uint8Array {
+  const bytes: number[] = [0];
+
+  for (const char of value) {
+    const carryIndex = BASE58BTC_ALPHABET.indexOf(char);
+    if (carryIndex === -1) {
+      throw new Error('invalid base58 cid');
+    }
+
+    let carry = carryIndex;
+    for (let i = 0; i < bytes.length; i += 1) {
+      const next = bytes[i] * 58 + carry;
+      bytes[i] = next & 0xff;
+      carry = next >> 8;
+    }
+
+    while (carry > 0) {
+      bytes.push(carry & 0xff);
+      carry >>= 8;
+    }
+  }
+
+  for (let i = 0; i < value.length && value[i] === BASE58BTC_ALPHABET[0]; i += 1) {
+    bytes.push(0);
+  }
+
+  bytes.reverse();
+  return Uint8Array.from(bytes);
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  return Array.from(bytes, (byte) => byte.toString(16).padStart(2, '0')).join(
+    '',
+  );
+}

--- a/apps/onchain/src/fee_tests.rs
+++ b/apps/onchain/src/fee_tests.rs
@@ -30,6 +30,10 @@ fn create_token_contract<'a>(
     (token_client, token_admin, token_address)
 }
 
+fn valid_metadata_hash(env: &Env) -> BytesN<32> {
+    BytesN::from_array(env, &[7u8; 32])
+}
+
 #[test]
 fn test_set_token_fee_valid() {
     let env = Env::default();
@@ -139,7 +143,7 @@ fn test_release_milestone_uses_global_fee_by_default() {
         &token_address,
         &milestones,
         &(env.ledger().timestamp() + 3600),
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
 
     token_client.approve(&depositor, &contract_id, &10_000, &200);
@@ -196,7 +200,7 @@ fn test_release_milestone_uses_token_fee_override() {
         &token_address,
         &milestones,
         &(env.ledger().timestamp() + 3600),
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
 
     token_client.approve(&depositor, &contract_id, &10_000, &200);
@@ -257,7 +261,7 @@ fn test_release_milestone_uses_escrow_fee_override() {
         &token_address,
         &milestones,
         &(env.ledger().timestamp() + 3600),
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
 
     token_client.approve(&depositor, &contract_id, &10_000, &200);
@@ -317,7 +321,7 @@ fn test_fee_precedence_escrow_over_token_and_global() {
         &token_address,
         &milestones,
         &(env.ledger().timestamp() + 3600),
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
 
     token_client.approve(&depositor, &contract_id, &10_000, &200);
@@ -371,7 +375,7 @@ fn test_cancel_escrow_uses_token_fee_override() {
         &token_address,
         &milestones,
         &(env.ledger().timestamp() + 3600),
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
 
     token_client.approve(&depositor, &contract_id, &10_000, &200);
@@ -428,7 +432,7 @@ fn test_refund_expired_uses_escrow_fee_override() {
         &token_address,
         &milestones,
         &deadline,
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
 
     token_client.approve(&depositor, &contract_id, &10_000, &200);
@@ -488,7 +492,7 @@ fn test_zero_fee_valid() {
         &token_address,
         &milestones,
         &(env.ledger().timestamp() + 3600),
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
 
     // Approve contract to transfer depositor's tokens, then deposit

--- a/apps/onchain/src/lib.rs
+++ b/apps/onchain/src/lib.rs
@@ -342,6 +342,7 @@ pub enum Error {
     Unauthorized = 27,
     OperatorNotInitialized = 28,
     ArbitratorNotInitialized = 29,
+    InvalidMetadataHash = 30,
 }
 
 const DEFAULT_FEE_BPS: i128 = 50;
@@ -711,6 +712,8 @@ impl VaultixEscrow {
             return Err(Error::SelfDealing);
         }
 
+        validate_metadata_hash(&metadata_hash)?;
+
         if env
             .storage()
             .persistent()
@@ -802,6 +805,8 @@ impl VaultixEscrow {
             if depositor == recipient {
                 return Err(Error::SelfDealing);
             }
+
+            validate_metadata_hash(&metadata_hash)?;
 
             for existing_id in escrow_ids.iter() {
                 if existing_id == escrow_id {
@@ -1702,6 +1707,14 @@ fn validate_milestones(milestones: &Vec<Milestone>) -> Result<i128, Error> {
             .ok_or(Error::InvalidMilestoneAmount)?;
     }
     Ok(total)
+}
+
+fn validate_metadata_hash(metadata_hash: &BytesN<32>) -> Result<(), Error> {
+    if metadata_hash.to_array() == [0u8; 32] {
+        return Err(Error::InvalidMetadataHash);
+    }
+
+    Ok(())
 }
 
 fn verify_all_released(milestones: &Vec<Milestone>) -> bool {

--- a/apps/onchain/src/test.rs
+++ b/apps/onchain/src/test.rs
@@ -23,6 +23,10 @@ fn create_token_contract<'a>(
     (token_client, token_admin, token_address)
 }
 
+fn valid_metadata_hash(env: &Env) -> BytesN<32> {
+    BytesN::from_array(env, &[7u8; 32])
+}
+
 #[test]
 fn test_create_escrow_fails_when_paused() {
     let env = Env::default();
@@ -67,7 +71,7 @@ fn test_create_escrow_fails_when_paused() {
         &token_address,
         &milestones,
         &deadline,
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
 
     assert_eq!(result, Err(Ok(Error::ContractPaused)));
@@ -112,7 +116,7 @@ fn test_deposit_funds_fails_when_paused() {
         &token_address,
         &milestones,
         &deadline,
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
 
     token_client.approve(&depositor, &contract_id, &10_000, &200);
@@ -167,7 +171,7 @@ fn test_create_and_get_escrow() {
         &token_address,
         &milestones,
         &deadline,
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
 
     let escrow = client.get_escrow(&escrow_id);
@@ -192,7 +196,7 @@ fn test_create_and_get_escrow() {
         .into_val(&env);
     assert_eq!(event.1, expected_topics);
 
-    let metadata_hash = BytesN::from_array(&env, &[0u8; 32]);
+    let metadata_hash = valid_metadata_hash(&env);
     let actual_payload: EscrowCreatedEvent = event.2.into_val(&env);
     assert_eq!(
         actual_payload,
@@ -213,6 +217,79 @@ fn test_create_and_get_escrow() {
     assert_eq!(token_client.balance(&depositor), 10000);
     assert_eq!(token_client.balance(&contract_id), 0);
     assert_eq!(token_client.balance(&recipient), 0);
+}
+
+#[test]
+fn test_create_escrow_rejects_zero_metadata_hash() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, VaultixEscrow);
+    let client = VaultixEscrowClient::new(&env, &contract_id);
+
+    let depositor = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let admin = Address::generate(&env);
+    let (_token_client, token_admin, token_address) = create_token_contract(&env, &admin);
+    token_admin.mint(&depositor, &10_000);
+
+    let milestones = vec![
+        &env,
+        Milestone {
+            amount: 10_000,
+            status: MilestoneStatus::Pending,
+            description: symbol_short!("Work"),
+        },
+    ];
+
+    let result = client.try_create_escrow(
+        &55u64,
+        &depositor,
+        &recipient,
+        &token_address,
+        &milestones,
+        &1_706_400_000u64,
+        &BytesN::from_array(&env, &[0u8; 32]),
+    );
+
+    assert_eq!(result, Err(Ok(Error::InvalidMetadataHash)));
+}
+
+#[test]
+fn test_create_escrows_batch_rejects_zero_metadata_hash() {
+    let env = Env::default();
+    env.mock_all_auths();
+
+    let contract_id = env.register_contract(None, VaultixEscrow);
+    let client = VaultixEscrowClient::new(&env, &contract_id);
+
+    let depositor = Address::generate(&env);
+    let recipient = Address::generate(&env);
+    let token_address = Address::generate(&env);
+    let milestones = vec![
+        &env,
+        Milestone {
+            amount: 10_000,
+            status: MilestoneStatus::Pending,
+            description: symbol_short!("Work"),
+        },
+    ];
+
+    let requests = vec![
+        &env,
+        CreateEscrowRequest {
+            escrow_id: 77u64,
+            depositor,
+            recipient,
+            token_address,
+            milestones,
+            deadline: 1_706_400_000u64,
+            metadata_hash: BytesN::from_array(&env, &[0u8; 32]),
+        },
+    ];
+
+    let result = client.try_create_escrows_batch(&requests);
+    assert_eq!(result, Err(Ok(Error::InvalidMetadataHash)));
 }
 
 #[test]
@@ -264,7 +341,7 @@ fn test_create_escrows_batch_and_get() {
             token_address: token_address.clone(),
             milestones: milestones_1,
             deadline: deadline_1,
-            metadata_hash: BytesN::from_array(&env, &[0u8; 32]),
+            metadata_hash: valid_metadata_hash(&env),
         },
         CreateEscrowRequest {
             escrow_id: escrow_id_2,
@@ -273,7 +350,7 @@ fn test_create_escrows_batch_and_get() {
             token_address: token_address.clone(),
             milestones: milestones_2,
             deadline: deadline_2,
-            metadata_hash: BytesN::from_array(&env, &[0u8; 32]),
+            metadata_hash: valid_metadata_hash(&env),
         },
     ];
 
@@ -319,7 +396,7 @@ fn test_create_escrows_batch_and_get() {
             token_address: escrow_1.token_address.clone(),
             total_amount: 10_000,
             deadline: deadline_1,
-            metadata_hash: BytesN::from_array(&env, &[0u8; 32]),
+            metadata_hash: valid_metadata_hash(&env),
         },
         EscrowCreatedBatchEventItem {
             escrow_id: escrow_id_2,
@@ -328,7 +405,7 @@ fn test_create_escrows_batch_and_get() {
             token_address: escrow_2.token_address.clone(),
             total_amount: 10_000,
             deadline: deadline_2,
-            metadata_hash: BytesN::from_array(&env, &[0u8; 32]),
+            metadata_hash: valid_metadata_hash(&env),
         },
     ];
     assert_eq!(
@@ -373,7 +450,7 @@ fn test_create_escrows_batch_is_atomic() {
             token_address: token_address.clone(),
             milestones: milestones.clone(),
             deadline: 1706400000u64,
-            metadata_hash: BytesN::from_array(&env, &[0u8; 32]),
+            metadata_hash: valid_metadata_hash(&env),
         },
         CreateEscrowRequest {
             escrow_id,
@@ -382,7 +459,7 @@ fn test_create_escrows_batch_is_atomic() {
             token_address,
             milestones,
             deadline: 1706403600u64,
-            metadata_hash: BytesN::from_array(&env, &[0u8; 32]),
+            metadata_hash: valid_metadata_hash(&env),
         },
     ];
 
@@ -437,7 +514,7 @@ fn test_deposit_funds() {
         &token_address,
         &milestones,
         &1706400000u64,
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
 
     // Approve contract to spend tokens
@@ -500,7 +577,7 @@ fn test_release_milestone_with_tokens() {
         &token_address,
         &milestones,
         &1706400000u64,
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
     token_client.approve(&depositor, &contract_id, &10_000, &200);
     client.deposit_funds(&escrow_id);
@@ -565,7 +642,7 @@ fn test_dispute_blocks_release() {
         &token_address,
         &milestones,
         &1706400000u64,
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
 
     token_client.approve(&depositor, &contract_id, &1000, &200);
@@ -621,7 +698,7 @@ fn test_complete_escrow_with_all_releases() {
         &token_address,
         &milestones,
         &1706400000u64,
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
     token_client.approve(&depositor, &contract_id, &10_000, &200);
     client.deposit_funds(&escrow_id);
@@ -675,7 +752,7 @@ fn test_cancel_escrow_with_refund() {
         &token_address,
         &milestones,
         &1706400000u64,
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
     token_client.approve(&depositor, &contract_id, &10_000, &200);
     client.deposit_funds(&escrow_id);
@@ -727,7 +804,7 @@ fn test_cancel_unfunded_escrow() {
         &token_address,
         &milestones,
         &1706400000u64,
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
 
     // Cancel unfunded escrow (no refund needed)
@@ -778,7 +855,7 @@ fn test_admin_resolves_dispute_to_recipient() {
         &token_address,
         &milestones,
         &1706400000u64,
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
 
     token_client.approve(&depositor, &contract_id, &10000, &200);
@@ -843,7 +920,7 @@ fn test_admin_resolves_dispute_to_depositor() {
         &token_address,
         &milestones,
         &1706400000u64,
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
 
     token_client.approve(&depositor, &contract_id, &5000, &200);
@@ -904,7 +981,7 @@ fn test_raise_dispute_happy_path() {
         &token_address,
         &milestones,
         &1706400000u64,
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
 
     let events_before = env.events().all().len();
@@ -981,7 +1058,7 @@ fn test_raise_dispute_invalid_status() {
         &token_address,
         &milestones,
         &1706400000u64,
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
     token_client.approve(&depositor, &contract_id, &5000, &200);
     client.deposit_funds(&escrow_id_completed);
@@ -1000,7 +1077,7 @@ fn test_raise_dispute_invalid_status() {
         &token_address,
         &milestones,
         &1706400000u64,
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
     token_client.approve(&depositor, &contract_id, &5000, &200);
     client.deposit_funds(&escrow_id_cancelled);
@@ -1047,7 +1124,7 @@ fn test_resolve_dispute_invalid_winner_or_overflow() {
         &token_address,
         &milestones,
         &1706400000u64,
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
     token_client.approve(&depositor, &contract_id, &1000, &200);
     client.deposit_funds(&escrow_id);
@@ -1098,7 +1175,7 @@ fn test_resolve_dispute_while_paused() {
         &token_address,
         &milestones,
         &1706400000u64,
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
     token_client.approve(&depositor, &contract_id, &5000, &200);
     client.deposit_funds(&escrow_id);
@@ -1149,7 +1226,7 @@ fn test_duplicate_escrow_id() {
         &token_address,
         &milestones,
         &1706400000u64,
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
     client.create_escrow(
         &escrow_id,
@@ -1158,7 +1235,7 @@ fn test_duplicate_escrow_id() {
         &token_address,
         &milestones,
         &1706400000u64,
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
 }
 
@@ -1198,7 +1275,7 @@ fn test_double_release() {
         &token_address,
         &milestones,
         &1706400000u64,
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
     token_client.approve(&depositor, &contract_id, &1000, &200);
     client.deposit_funds(&escrow_id);
@@ -1244,7 +1321,7 @@ fn test_too_many_milestones() {
         &token_address,
         &milestones,
         &1706400000u64,
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
 }
 
@@ -1281,7 +1358,7 @@ fn test_invalid_milestone_amount() {
         &token_address,
         &milestones,
         &1706400000u64,
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
 }
 
@@ -1319,7 +1396,7 @@ fn test_unauthorized_confirm_delivery() {
         &token_address,
         &milestones,
         &1706400000u64,
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
 
     token_client.approve(&buyer, &contract_id, &1000, &200);
@@ -1363,7 +1440,7 @@ fn test_double_confirm_delivery() {
         &token_address,
         &milestones,
         &1706400000u64,
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
 
     token_client.approve(&buyer, &contract_id, &1000, &200);
@@ -1406,7 +1483,7 @@ fn test_zero_amount_milestone_rejected() {
         &token_address,
         &milestones,
         &1706400000u64,
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
 
     assert_eq!(result, Err(Ok(Error::ZeroAmount)));
@@ -1443,7 +1520,7 @@ fn test_negative_amount_milestone_rejected() {
         &token_address,
         &milestones,
         &1706400000u64,
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
 
     assert_eq!(result, Err(Ok(Error::ZeroAmount)));
@@ -1479,7 +1556,7 @@ fn test_self_dealing_rejected() {
         &token_address,
         &milestones,
         &1706400000u64,
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
 
     assert_eq!(result, Err(Ok(Error::SelfDealing)));
@@ -1521,7 +1598,7 @@ fn test_valid_escrow_creation_succeeds() {
         &token_address,
         &milestones,
         &1706400000u64,
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
 
     assert!(result.is_ok());
@@ -1567,7 +1644,7 @@ fn test_double_deposit_rejected() {
         &token_address,
         &milestones,
         &1706400000u64,
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
 
     token_client.approve(&depositor, &contract_id, &10_000, &200);
@@ -1612,7 +1689,7 @@ fn test_cancel_active_escrow_retains_fee() {
         &token_address,
         &milestones,
         &1706400000u64,
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
     token_client.approve(&depositor, &contract_id, &10_000, &200);
     client.deposit_funds(&escrow_id);
@@ -1666,7 +1743,7 @@ fn test_release_milestone_before_deposit() {
         &token_address,
         &milestones,
         &1706400000u64,
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
 
     // Try to release milestone before depositing funds
@@ -1713,7 +1790,7 @@ fn test_refund_expired_authorization_check() {
         &token_address,
         &milestones,
         &deadline,
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
     token_client.approve(&depositor, &contract_id, &10_000, &200);
     client.deposit_funds(&escrow_id);
@@ -1774,7 +1851,7 @@ fn test_resolve_dispute_fails_without_arbitrator_initialized() {
         &token_address,
         &milestones,
         &1706400000u64,
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
     token_client.approve(&depositor, &contract_id, &1000, &200);
     client.deposit_funds(&escrow_id);
@@ -1947,7 +2024,7 @@ fn test_release_milestone_uses_global_fee_by_default() {
         &token_address,
         &milestones,
         &(env.ledger().timestamp() + 3600),
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
 
     // Approve contract to transfer depositor's tokens, then deposit
@@ -2003,7 +2080,7 @@ fn test_release_milestone_uses_token_fee_override() {
         &token_address,
         &milestones,
         &(env.ledger().timestamp() + 3600),
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
 
     // Approve contract to transfer depositor's tokens, then deposit
@@ -2064,7 +2141,7 @@ fn test_release_milestone_uses_escrow_fee_override() {
         &token_address,
         &milestones,
         &(env.ledger().timestamp() + 3600),
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
 
     // Approve contract to transfer depositor's tokens, then deposit
@@ -2121,7 +2198,7 @@ fn test_cancel_escrow_uses_token_fee_override() {
         &token_address,
         &milestones,
         &(env.ledger().timestamp() + 3600),
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
 
     // Approve contract to transfer depositor's tokens, then deposit
@@ -2245,7 +2322,7 @@ fn test_refund_expired_uses_escrow_fee_override() {
         &token_address,
         &milestones,
         &deadline,
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
 
     // Approve contract to transfer depositor's tokens, then deposit
@@ -2361,7 +2438,7 @@ fn test_zero_fee_valid() {
         &token_address,
         &milestones,
         &(env.ledger().timestamp() + 3600),
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
     // Approve contract to transfer depositor's tokens, then deposit
     token_client.approve(&depositor, &contract_id, &10_000, &200);
@@ -2410,7 +2487,7 @@ fn test_configure_multisig_threshold() {
         &token_address,
         &milestones,
         &1706400000u64,
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
 
     // Configure multisig: threshold of 3000 and require 2 signatures
@@ -2457,7 +2534,7 @@ fn test_collect_signature() {
         &token_address,
         &milestones,
         &1706400000u64,
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
 
     // Configure multisig: threshold of 3000 and require 2 signatures
@@ -2514,7 +2591,7 @@ fn test_release_milestone_below_threshold_single_signature() {
         &token_address,
         &milestones,
         &1706400000u64,
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
 
     // Configure multisig: threshold of 3000 and require 2 signatures
@@ -2568,7 +2645,7 @@ fn test_release_milestone_above_threshold_insufficient_signatures() {
         &token_address,
         &milestones,
         &1706400000u64,
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
 
     // Configure multisig: threshold of 3000 and require 2 signatures
@@ -2616,7 +2693,7 @@ fn test_release_milestone_above_threshold_sufficient_signatures() {
         &token_address,
         &milestones,
         &1706400000u64,
-        &BytesN::from_array(&env, &[0u8; 32]),
+        &valid_metadata_hash(&env),
     );
 
     // Configure multisig: threshold of 3000 and require 2 signatures

--- a/docs/contract/DATA_MODELS.md
+++ b/docs/contract/DATA_MODELS.md
@@ -17,8 +17,22 @@ pub struct Escrow {
     pub status: EscrowStatus,      // Current state of the escrow
     pub deadline: u64,             // Expiration timestamp for refunds
     pub resolution: Resolution,    // Outcome if a dispute occurred
+    pub metadata_hash: BytesN<32>, // Canonical 32-byte metadata digest
 }
 ```
+
+### `metadata_hash` Canonical Format
+- On-chain `metadata_hash` is exactly 32 raw bytes.
+- Off-chain clients should represent the same value as lowercase 64-character hex.
+- The canonical bytes are the SHA-256 digest bytes, not the CID string bytes.
+- For IPFS references, clients should decode the CID multihash and extract the 32-byte `sha2-256` digest.
+- The all-zero digest is rejected as malformed input.
+
+### IPFS / CID Strategy
+- Preferred display form: `ipfs://<cid>`.
+- Preferred write path: CIDv1 base32 using `sha2-256`.
+- Interop rule: backend/frontend normalize either a raw 32-byte hex digest or an IPFS CID into the same lowercase 64-character hex string, then pass those bytes on-chain.
+- Determinism requirement: the metadata payload must be serialized identically before upload; otherwise a new CID and digest will be produced.
 
 ### `Milestone`
 Represents an individual chunk of the total payout.

--- a/docs/contract/ERRORS.md
+++ b/docs/contract/ERRORS.md
@@ -33,3 +33,4 @@ Below is a complete reference of the `Error` enum variants returned by the `Vaul
 | `Unauthorized` | 27 | Similar to (5), unauthorized function caller specifically for expiration refund. | Check who you are logging in with. |
 | `OperatorNotInitialized` | 28 | `operator` address missing in persistent storage. | Contact Admin to supply this config. |
 | `ArbitratorNotInitialized` | 29 | `arbitrator` address missing in persistent storage. | Contact Admin to supply this config. |
+| `InvalidMetadataHash` | 30 | `metadata_hash` was the all-zero 32-byte value or otherwise failed metadata validation. | Pass a real 32-byte SHA-256 digest derived from the metadata CID or payload. |

--- a/docs/contract/README.md
+++ b/docs/contract/README.md
@@ -39,3 +39,13 @@ The contract defines several key roles, each with specific permissions:
 - **Arbitrator**: A trusted third party authorized to resolve disputes between the depositor and recipient, deciding how funds are distributed.
 - **Depositor**: The user who creates the escrow, funds it with tokens, and has the authority to release milestones (or confirm delivery) to the recipient.
 - **Recipient**: The user designated to receive the funds upon the completion of milestones.
+
+## Metadata Hash Interop
+
+`create_escrow` stores a `metadata_hash` as `BytesN<32>`. The canonical meaning of that field is the raw 32-byte `sha2-256` digest of the escrow metadata reference.
+
+- On-chain form: raw 32 bytes.
+- API/client form: lowercase 64-character hex string of those same 32 bytes.
+- Display form: prefer `ipfs://<cid>` for users.
+- CID mapping: when metadata is pinned to IPFS, decode the CID multihash and extract the `sha2-256` digest bytes. New writes should prefer CIDv1 base32.
+- Validation: the contract rejects the all-zero digest, and off-chain clients reject malformed hex/CID inputs.


### PR DESCRIPTION
## Summary

Standardized `metadata_hash` as a canonical 32-byte SHA-256 digest, added contract-side validation to reject invalid zero hashes, and aligned backend/frontend normalization for IPFS CID interop.

## Changes

- Reject invalid `metadata_hash` values in `create_escrow` and batch creation
- Normalize CID or hex metadata references into the same 32-byte digest format off-chain
- Pass normalized metadata bytes through backend on-chain calls
- Add tests and docs for validation and IPFS/CID mapping

 - Close #217 