### PR TITLE
fix: add missing closing brace in lib.rs to fix compilation error

### DIFF
--- a/apps/onchain/src/lib.rs
+++ b/apps/onchain/src/lib.rs
@@ -2083,3 +2083,4 @@ fn seconds_to_ledgers(seconds: u64) -> u32 {
 mod fee_tests;
 #[cfg(test)]
 mod test;
+}


### PR DESCRIPTION
fix: add missing closing brace in lib.rs to fix compilation error

