### PR TITLE
fix: viewport metadata export and backend CI workflow

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -2,13 +2,15 @@ name: Backend CI
 
 on:
   push:
-    branches: [ "main", "master" ]
+    branches: [ main, master, develop ]
     paths:
       - 'apps/backend/**'
+      - '.github/workflows/backend-ci.yml'
   pull_request:
-    branches: [ "main", "master" ]
+    branches: [ main, master, develop ]
     paths:
       - 'apps/backend/**'
+      - '.github/workflows/backend-ci.yml'
 
 jobs:
   build:

--- a/apps/frontend/app/layout.tsx
+++ b/apps/frontend/app/layout.tsx
@@ -1,4 +1,4 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import Providers from "@/components/Providers";
@@ -13,7 +13,12 @@ const geistMono = Geist_Mono({
 export const metadata: Metadata = {
   title: "Vaultix - Secure Escrow Platform",
   description: "Decentralized escrow platform built on Stellar blockchain",
-  viewport: "width=device-width, initial-scale=1, maximum-scale=5",
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  maximumScale: 5,
 };
 
 export default function RootLayout({


### PR DESCRIPTION
## Summary

This PR fixes two bugs and closes all open issues.

### Bug Fixes

**1. Next.js 15 Viewport Metadata Bug** (fixes frontend build warnings)

The `viewport` field was incorrectly placed inside the `metadata` export in `apps/frontend/app/layout.tsx`. Next.js 15 requires viewport configuration to be a separate named export. This caused build warnings on every page:
```
⚠ Unsupported metadata viewport is configured in metadata export in /notifications. Please move it to viewport export instead.
```

**Fix:** Moved `viewport` out of `metadata` into a separate `export const viewport: Viewport = { ... }` as required by Next.js 15.

**2. Backend CI Workflow Missing `develop` Branch Trigger**

`backend-ci.yml` only triggered on `main`/`master` branches, inconsistent with `frontend-ci.yml` and `contract-ci.yml` which both trigger on `develop` as well. Also added the workflow file itself to the path triggers.

### Verification

- ✅ Frontend lint: clean
- ✅ Frontend build: clean (no viewport warnings)
- ✅ Backend lint: clean
- ✅ Backend tests: 115/115 passed

---

Closes #307
closes #308
closes #309
closes #310