### PR TITLE
feat: add emergency pause circuit breaker utility

### DIFF
--- a/apps/backend/src/modules/escrow/utils/emergency-pause.util.ts
+++ b/apps/backend/src/modules/escrow/utils/emergency-pause.util.ts
@@ -1,0 +1,44 @@
+/**
+ * Emergency pause circuit breaker.
+ * Tracks pause state in-memory and exposes helpers to pause, resume,
+ * and check whether operations are currently allowed.
+ */
+
+let paused = false;
+let pausedAt: Date | null = null;
+let pausedBy: string | null = null;
+
+export interface PauseState {
+  paused: boolean;
+  pausedAt: Date | null;
+  pausedBy: string | null;
+}
+
+/** Activates the circuit breaker, blocking all guarded operations. */
+export function activatePause(adminId: string): void {
+  paused = true;
+  pausedAt = new Date();
+  pausedBy = adminId;
+}
+
+/** Deactivates the circuit breaker, resuming normal operations. */
+export function deactivatePause(): void {
+  paused = false;
+  pausedAt = null;
+  pausedBy = null;
+}
+
+/** Returns the current pause state. */
+export function getPauseState(): PauseState {
+  return { paused, pausedAt, pausedBy };
+}
+
+/**
+ * Throws an error if the system is currently paused.
+ * Use this guard at the start of any sensitive operation.
+ */
+export function assertNotPaused(): void {
+  if (paused) {
+    throw new Error(`System is paused (since ${pausedAt?.toISOString()}, by ${pausedBy})`);
+  }
+}


### PR DESCRIPTION
Adds emergency-pause.util.ts with activatePause, deactivatePause, getPauseState, and assertNotPaused helpers to block all guarded operations when the circuit breaker is active.

closes #138