### PR TITLE
feat: add retry/backoff, offline UI, and user-friendly error messages…

### DIFF
--- a/apps/mobile/__tests__/api.test.ts
+++ b/apps/mobile/__tests__/api.test.ts
@@ -1,7 +1,9 @@
 /**
- * Basic unit tests for mobile escrow screens
+ * Unit tests for mobile API services + reliability utilities
  */
 import { escrowApi } from '../services/api';
+import { isRetryableError, withRetry } from '../utils/retry';
+import { toFriendlyError, isOfflineError } from '../utils/errors';
 
 // Mock axios
 jest.mock('axios', () => ({
@@ -19,6 +21,122 @@ describe('escrowApi', () => {
     expect(typeof escrowApi.create).toBe('function');
     expect(typeof escrowApi.releaseMilestone).toBe('function');
     expect(typeof escrowApi.getTxStatus).toBe('function');
+  });
+});
+
+describe('isRetryableError', () => {
+  it('retries on network errors', () => {
+    expect(isRetryableError({ code: 'ECONNABORTED' })).toBe(true);
+    expect(isRetryableError({ code: 'ERR_NETWORK' })).toBe(true);
+    expect(isRetryableError({ code: 'ETIMEDOUT' })).toBe(true);
+  });
+
+  it('retries on 5xx and 429', () => {
+    expect(isRetryableError({ response: { status: 500 } })).toBe(true);
+    expect(isRetryableError({ response: { status: 502 } })).toBe(true);
+    expect(isRetryableError({ response: { status: 429 } })).toBe(true);
+  });
+
+  it('does not retry on 4xx client errors', () => {
+    expect(isRetryableError({ response: { status: 400 } })).toBe(false);
+    expect(isRetryableError({ response: { status: 404 } })).toBe(false);
+    expect(isRetryableError({ response: { status: 403 } })).toBe(false);
+  });
+
+  it('returns false for null/undefined', () => {
+    expect(isRetryableError(null)).toBe(false);
+    expect(isRetryableError(undefined)).toBe(false);
+  });
+});
+
+describe('withRetry', () => {
+  it('returns result on first success', async () => {
+    const fn = jest.fn().mockResolvedValue('ok');
+    const result = await withRetry(fn, { maxRetries: 2, jitter: false });
+    expect(result).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+
+  it('retries on retryable error and eventually succeeds', async () => {
+    const fn = jest.fn()
+      .mockRejectedValueOnce({ code: 'ECONNABORTED' })
+      .mockResolvedValueOnce('ok');
+    const result = await withRetry(fn, { maxRetries: 2, initialDelayMs: 10, jitter: false });
+    expect(result).toBe('ok');
+    expect(fn).toHaveBeenCalledTimes(2);
+  });
+
+  it('throws after max retries exhausted', async () => {
+    const fn = jest.fn().mockRejectedValue({ code: 'ECONNABORTED' });
+    await expect(withRetry(fn, { maxRetries: 1, initialDelayMs: 10, jitter: false }))
+      .rejects.toEqual({ code: 'ECONNABORTED' });
+    expect(fn).toHaveBeenCalledTimes(2); // initial + 1 retry
+  });
+
+  it('does not retry non-retryable errors', async () => {
+    const fn = jest.fn().mockRejectedValue({ response: { status: 404 } });
+    await expect(withRetry(fn, { maxRetries: 3, jitter: false }))
+      .rejects.toEqual({ response: { status: 404 } });
+    expect(fn).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe('isOfflineError', () => {
+  it('detects offline error codes', () => {
+    expect(isOfflineError({ code: 'ERR_NETWORK' })).toBe(true);
+    expect(isOfflineError({ code: 'ECONNREFUSED' })).toBe(true);
+    expect(isOfflineError({ code: 'ENOTFOUND' })).toBe(true);
+  });
+
+  it('detects request-without-response pattern', () => {
+    expect(isOfflineError({ request: {} })).toBe(true);
+  });
+
+  it('returns false for server errors', () => {
+    expect(isOfflineError({ response: { status: 500 } })).toBe(false);
+  });
+});
+
+describe('toFriendlyError', () => {
+  it('maps offline errors to friendly messages', () => {
+    const result = toFriendlyError({ code: 'ERR_NETWORK' });
+    expect(result.isOffline).toBe(true);
+    expect(result.title).toBe('No internet connection');
+    expect(result.message).toContain('offline');
+  });
+
+  it('maps 404 to friendly message', () => {
+    const result = toFriendlyError({ response: { status: 404 } });
+    expect(result.isOffline).toBe(false);
+    expect(result.title).toBe('Not found');
+  });
+
+  it('maps 500 with testnet context', () => {
+    const result = toFriendlyError({ response: { status: 500 } });
+    expect(result.isRetryable).toBe(true);
+    expect(result.message).toContain('testnet');
+  });
+
+  it('maps 503 with testnet context', () => {
+    const result = toFriendlyError({ response: { status: 503 } });
+    expect(result.isRetryable).toBe(true);
+    expect(result.message).toContain('testnet');
+  });
+
+  it('maps 401 to session expired', () => {
+    const result = toFriendlyError({ response: { status: 401 } });
+    expect(result.title).toBe('Session expired');
+    expect(result.message).toContain('wallet');
+  });
+
+  it('handles unknown errors gracefully', () => {
+    const result = toFriendlyError(null);
+    expect(result.title).toBe('Something went wrong');
+  });
+
+  it('prefers server message when available', () => {
+    const result = toFriendlyError({ response: { status: 400, data: { message: 'Custom server error' } } });
+    expect(result.message).toBe('Custom server error');
   });
 });
 

--- a/apps/mobile/app/dashboard.tsx
+++ b/apps/mobile/app/dashboard.tsx
@@ -15,6 +15,9 @@ import {
 import { useRouter } from 'expo-router';
 import { escrowApi } from '../services/api';
 import { Escrow, EscrowStatus } from '../types/escrow';
+import { OfflineBanner } from '../components/OfflineBanner';
+import { useNetworkStatus } from '../hooks/useNetworkStatus';
+import { toFriendlyError, isOfflineError } from '../utils/errors';
 
 const STATUS_FILTERS: Array<{ label: string; value: EscrowStatus | 'all' }> = [
   { label: 'All', value: 'all' },
@@ -68,10 +71,12 @@ export default function DashboardScreen() {
   const [activeFilter, setActiveFilter] = useState<EscrowStatus | 'all'>('all');
   const [escrows, setEscrows] = useState<Escrow[]>([]);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<{ title: string; message: string } | null>(null);
   const [refreshing, setRefreshing] = useState(false);
   const [loadingMore, setLoadingMore] = useState(false);
   const [hasNextPage, setHasNextPage] = useState(false);
   const pageRef = useRef(1);
+  const { isOffline, markOffline, markOnline } = useNetworkStatus();
 
   const fetchEscrows = useCallback(async (status: EscrowStatus | 'all', page: number, append = false) => {
     try {
@@ -79,10 +84,14 @@ export default function DashboardScreen() {
       setEscrows((prev) => (append ? [...prev, ...res.escrows] : res.escrows));
       setHasNextPage(res.hasNextPage);
       pageRef.current = page;
-    } catch {
-      // silently fail – in production show a toast
+      setError(null);
+      markOnline();
+    } catch (err) {
+      const friendly = toFriendlyError(err);
+      setError({ title: friendly.title, message: friendly.message });
+      if (isOfflineError(err)) markOffline();
     }
-  }, []);
+  }, [markOnline, markOffline]);
 
   useEffect(() => {
     setLoading(true);
@@ -104,6 +113,8 @@ export default function DashboardScreen() {
 
   return (
     <View style={styles.container}>
+      <OfflineBanner visible={isOffline} />
+
       {/* Status filter tabs */}
       <FlatList
         horizontal
@@ -129,6 +140,15 @@ export default function DashboardScreen() {
       {loading ? (
         <View style={styles.skeletonList}>
           {[1, 2, 3, 4].map((k) => <SkeletonCard key={k} />)}
+        </View>
+      ) : error ? (
+        <View style={styles.errorContainer}>
+          <Text style={styles.errorEmoji}>⚠️</Text>
+          <Text style={styles.errorTitle}>{error.title}</Text>
+          <Text style={styles.errorMessage}>{error.message}</Text>
+          <TouchableOpacity style={styles.retryBtn} onPress={onRefresh}>
+            <Text style={styles.retryText}>Retry</Text>
+          </TouchableOpacity>
         </View>
       ) : (
         <FlatList
@@ -173,6 +193,12 @@ const styles = StyleSheet.create({
   cardAmount: { color: '#6c63ff', fontWeight: '700', fontSize: 18, marginBottom: 4 },
   cardMeta: { color: '#888', fontSize: 12 },
   empty: { color: '#888', textAlign: 'center', marginTop: 60, fontSize: 15 },
+  errorContainer: { alignItems: 'center', justifyContent: 'center', marginTop: 60, paddingHorizontal: 32 },
+  errorEmoji: { fontSize: 36, marginBottom: 8 },
+  errorTitle: { color: '#ef476f', fontSize: 16, fontWeight: '700', marginBottom: 6, textAlign: 'center' },
+  errorMessage: { color: '#aaa', fontSize: 13, textAlign: 'center', lineHeight: 18, marginBottom: 16 },
+  retryBtn: { backgroundColor: '#6c63ff', borderRadius: 10, paddingHorizontal: 24, paddingVertical: 10 },
+  retryText: { color: '#fff', fontWeight: '600' },
   skeletonList: { padding: 16 },
   skeletonCard: { backgroundColor: '#1e1e30', borderRadius: 12, padding: 16, marginBottom: 12 },
   skeletonTitle: { height: 16, backgroundColor: '#2d2d44', borderRadius: 4, marginBottom: 10, width: '70%' },

--- a/apps/mobile/app/escrow/[id].tsx
+++ b/apps/mobile/app/escrow/[id].tsx
@@ -13,6 +13,9 @@ import {
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { escrowApi } from '../../services/api';
 import { Escrow, Milestone, Party, EscrowEvent } from '../../types/escrow';
+import { OfflineBanner } from '../../components/OfflineBanner';
+import { useNetworkStatus } from '../../hooks/useNetworkStatus';
+import { toFriendlyError, isOfflineError } from '../../utils/errors';
 
 // Simulated current user role – in production this comes from auth context
 const CURRENT_USER_ROLE: 'depositor' | 'recipient' | 'arbitrator' = 'depositor';
@@ -91,7 +94,8 @@ export default function EscrowDetailScreen() {
   const router = useRouter();
   const [escrow, setEscrow] = useState<Escrow | null>(null);
   const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
+  const [error, setError] = useState<{ title: string; message: string } | null>(null);
+  const { isOffline, markOffline, markOnline } = useNetworkStatus();
 
   const load = useCallback(async () => {
     if (!id) return;
@@ -99,12 +103,15 @@ export default function EscrowDetailScreen() {
       setError(null);
       const data = await escrowApi.getById(id);
       setEscrow(data);
-    } catch {
-      setError('Failed to load escrow. Please try again.');
+      markOnline();
+    } catch (err) {
+      const friendly = toFriendlyError(err);
+      setError({ title: friendly.title, message: friendly.message });
+      if (isOfflineError(err)) markOffline();
     } finally {
       setLoading(false);
     }
-  }, [id]);
+  }, [id, markOnline, markOffline]);
 
   useEffect(() => { load(); }, [load]);
 
@@ -117,11 +124,16 @@ export default function EscrowDetailScreen() {
   }
   if (error || !escrow) {
     return (
-      <View style={styles.center}>
-        <Text style={styles.errorText}>{error ?? 'Escrow not found.'}</Text>
-        <TouchableOpacity style={styles.retryBtn} onPress={load}>
-          <Text style={styles.retryText}>Retry</Text>
-        </TouchableOpacity>
+      <View style={styles.root}>
+        <OfflineBanner visible={isOffline} />
+        <View style={styles.center}>
+          <Text style={styles.errorEmoji}>⚠️</Text>
+          <Text style={styles.errorTitle}>{error?.title ?? 'Not found'}</Text>
+          <Text style={styles.errorMessage}>{error?.message ?? 'Escrow not found.'}</Text>
+          <TouchableOpacity style={styles.retryBtn} onPress={load}>
+            <Text style={styles.retryText}>Retry</Text>
+          </TouchableOpacity>
+        </View>
       </View>
     );
   }
@@ -133,7 +145,9 @@ export default function EscrowDetailScreen() {
     ['funded', 'confirmed'].includes(escrow.status);
 
   return (
-    <ScrollView style={styles.container} contentContainerStyle={styles.content}>
+    <View style={styles.root}>
+      <OfflineBanner visible={isOffline} />
+      <ScrollView style={styles.container} contentContainerStyle={styles.content}>
       {/* Header */}
       <View style={styles.header}>
         <Text style={styles.title}>{escrow.title}</Text>
@@ -204,11 +218,13 @@ export default function EscrowDetailScreen() {
           <Text style={styles.noActions}>No actions available for this status.</Text>
         )}
       </Section>
-    </ScrollView>
+      </ScrollView>
+    </View>
   );
 }
 
 const styles = StyleSheet.create({
+  root: { flex: 1, backgroundColor: '#12121f' },
   container: { flex: 1, backgroundColor: '#12121f' },
   content: { padding: 16, paddingBottom: 40 },
   center: { flex: 1, alignItems: 'center', justifyContent: 'center', backgroundColor: '#12121f' },
@@ -245,7 +261,9 @@ const styles = StyleSheet.create({
   actionBtn: { borderRadius: 12, paddingVertical: 14, alignItems: 'center', marginBottom: 10 },
   actionBtnText: { color: '#fff', fontWeight: '600', fontSize: 15 },
   noActions: { color: '#888', fontSize: 13, textAlign: 'center', paddingVertical: 8 },
-  errorText: { color: '#ef476f', fontSize: 15, marginBottom: 16 },
+  errorEmoji: { fontSize: 36, marginBottom: 8 },
+  errorTitle: { color: '#ef476f', fontSize: 16, fontWeight: '700', marginBottom: 6, textAlign: 'center' },
+  errorMessage: { color: '#aaa', fontSize: 13, textAlign: 'center', lineHeight: 18, marginBottom: 16 },
   retryBtn: { backgroundColor: '#6c63ff', borderRadius: 10, paddingHorizontal: 24, paddingVertical: 12 },
   retryText: { color: '#fff', fontWeight: '600' },
 });

--- a/apps/mobile/app/escrow/create.tsx
+++ b/apps/mobile/app/escrow/create.tsx
@@ -18,6 +18,7 @@ import {
 } from 'react-native';
 import { useRouter } from 'expo-router';
 import { escrowApi } from '../../services/api';
+import { toFriendlyError } from '../../utils/errors';
 
 const MAX_MILESTONES = 10;
 const MIN_MILESTONES = 1;
@@ -176,8 +177,9 @@ export default function CreateEscrowScreen() {
         { text: 'View', onPress: () => router.replace({ pathname: '/escrow/[id]', params: { id: created.id } }) },
         { text: 'Dashboard', onPress: () => router.replace('/dashboard') },
       ]);
-    } catch {
-      Alert.alert('Error', 'Failed to create escrow. Please try again.');
+    } catch (err) {
+      const friendly = toFriendlyError(err);
+      Alert.alert(friendly.title, friendly.message, [{ text: 'OK' }]);
     } finally {
       setSubmitting(false);
     }

--- a/apps/mobile/app/escrow/release.tsx
+++ b/apps/mobile/app/escrow/release.tsx
@@ -14,6 +14,7 @@ import {
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { escrowApi } from '../../services/api';
 import { TxState, TxStatus } from '../../types/escrow';
+import { toFriendlyError } from '../../utils/errors';
 
 const POLL_INTERVAL_MS = 3000;
 const MAX_POLLS = 20; // ~60 s timeout
@@ -188,13 +189,14 @@ export default function ReleaseMilestoneScreen() {
 }
 
 function getErrorMessage(err: unknown): string {
+  const friendly = toFriendlyError(err);
+  // For release-specific context, provide more specific messages
   if (err && typeof err === 'object' && 'response' in err) {
-    const axiosErr = err as { response?: { data?: { message?: string }; status?: number } };
-    if (axiosErr.response?.status === 403) return 'Unauthorized: you cannot release this milestone.';
+    const axiosErr = err as { response?: { status?: number } };
+    if (axiosErr.response?.status === 403) return 'You don\'t have permission to release this milestone.';
     if (axiosErr.response?.status === 402) return 'Insufficient balance to complete this transaction.';
-    if (axiosErr.response?.data?.message) return axiosErr.response.data.message;
   }
-  return 'An unexpected error occurred. Please try again.';
+  return friendly.message;
 }
 
 const styles = StyleSheet.create({

--- a/apps/mobile/components/OfflineBanner.tsx
+++ b/apps/mobile/components/OfflineBanner.tsx
@@ -1,0 +1,39 @@
+/**
+ * OfflineBanner – shown at top of screens when network is unavailable.
+ * Reuses the app's dark theme palette.
+ */
+import React from 'react';
+import { StyleSheet, Text, View } from 'react-native';
+
+interface OfflineBannerProps {
+  visible: boolean;
+}
+
+export function OfflineBanner({ visible }: OfflineBannerProps) {
+  if (!visible) return null;
+
+  return (
+    <View style={styles.banner}>
+      <Text style={styles.icon}>📡</Text>
+      <View style={styles.textContainer}>
+        <Text style={styles.title}>You're offline</Text>
+        <Text style={styles.subtitle}>Check your connection — some features won't be available</Text>
+      </View>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  banner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: '#f77f00',
+    paddingHorizontal: 16,
+    paddingVertical: 10,
+    gap: 10,
+  },
+  icon: { fontSize: 18 },
+  textContainer: { flex: 1 },
+  title: { color: '#1a1a2e', fontWeight: '700', fontSize: 13 },
+  subtitle: { color: '#1a1a2e', fontSize: 11, marginTop: 1, opacity: 0.85 },
+});

--- a/apps/mobile/hooks/useNetworkStatus.ts
+++ b/apps/mobile/hooks/useNetworkStatus.ts
@@ -1,0 +1,75 @@
+/**
+ * Network connectivity hook for offline detection.
+ * Uses @react-native-community/netinfo when available, falls back to error-based detection.
+ */
+import { useState, useEffect, useCallback } from 'react';
+
+interface NetInfoState {
+  isConnected: boolean | null;
+  isInternetReachable: boolean | null;
+  type: string;
+}
+
+const DEFAULT_STATE: NetInfoState = {
+  isConnected: null,
+  isInternetReachable: null,
+  type: 'unknown',
+};
+
+let NetInfoModule: typeof import('@react-native-community/netinfo') | null = null;
+
+try {
+  NetInfoModule = require('@react-native-community/netinfo');
+} catch {
+  // NetInfo not installed — we'll use a fallback approach
+}
+
+export function useNetworkStatus() {
+  const [isOffline, setIsOffline] = useState(false);
+  const [connectionType, setConnectionType] = useState<string>('unknown');
+
+  const checkConnectivity = useCallback(async (): Promise<boolean> => {
+    if (NetInfoModule) {
+      try {
+        const state = await NetInfoModule.fetch();
+        const connected = state.isConnected ?? true;
+        setIsOffline(!connected);
+        setConnectionType(state.type ?? 'unknown');
+        return connected;
+      } catch {
+        return true; // Assume online if check fails
+      }
+    }
+    return true; // Assume online if NetInfo not available
+  }, []);
+
+  useEffect(() => {
+    if (!NetInfoModule) return;
+
+    // Subscribe to connectivity changes
+    const unsubscribe = NetInfoModule.addEventListener((state) => {
+      const connected = state.isConnected ?? true;
+      setIsOffline(!connected);
+      setConnectionType(state.type ?? 'unknown');
+    });
+
+    // Initial check
+    checkConnectivity();
+
+    return () => {
+      if (typeof unsubscribe === 'function') {
+        unsubscribe();
+      }
+    };
+  }, [checkConnectivity]);
+
+  return {
+    isOffline,
+    connectionType,
+    checkConnectivity,
+    /** Mark as offline manually (used when API call fails with network error) */
+    markOffline: useCallback(() => setIsOffline(true), []),
+    /** Mark as online manually (used when API call succeeds) */
+    markOnline: useCallback(() => setIsOffline(false), []),
+  };
+}

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -19,7 +19,8 @@
     "@react-navigation/native": "^6.1.18",
     "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "~4.4.0",
-    "axios": "^1.7.9"
+    "axios": "^1.7.9",
+    "@react-native-community/netinfo": "^11.4.1"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/apps/mobile/services/api.ts
+++ b/apps/mobile/services/api.ts
@@ -6,6 +6,7 @@ import {
   CreateEscrowPayload,
   ReleaseMilestonePayload,
 } from '../types/escrow';
+import { withRetry } from '../utils/retry';
 
 const API_BASE_URL = process.env.EXPO_PUBLIC_API_BASE_URL ?? 'http://localhost:3000';
 
@@ -26,32 +27,36 @@ api.interceptors.request.use((config) => {
 });
 
 export const escrowApi = {
-  /** #314 – list escrows with status filter + pagination */
+  /** #314 – list escrows with status filter + pagination (auto-retry on testnet failures) */
   list: async (filters: EscrowFilters = {}): Promise<EscrowListResponse> => {
-    const params: Record<string, string | number> = {
-      page: filters.page ?? 1,
-      limit: filters.limit ?? 20,
-    };
-    if (filters.status && filters.status !== 'all') params.status = filters.status;
-    if (filters.search) params.search = filters.search;
+    return withRetry(async () => {
+      const params: Record<string, string | number> = {
+        page: filters.page ?? 1,
+        limit: filters.limit ?? 20,
+      };
+      if (filters.status && filters.status !== 'all') params.status = filters.status;
+      if (filters.search) params.search = filters.search;
 
-    const { data } = await api.get<EscrowListResponse>('/api/escrows', { params });
-    return data;
+      const { data } = await api.get<EscrowListResponse>('/api/escrows', { params });
+      return data;
+    }, { maxRetries: 2 }); // Lighter retry for list calls to avoid stale data
   },
 
-  /** #315 – get single escrow with milestones, parties, events */
+  /** #315 – get single escrow with milestones, parties, events (auto-retry) */
   getById: async (id: string): Promise<Escrow> => {
-    const { data } = await api.get<Escrow>(`/api/escrows/${id}`);
-    return data;
+    return withRetry(async () => {
+      const { data } = await api.get<Escrow>(`/api/escrows/${id}`);
+      return data;
+    }, { maxRetries: 3 });
   },
 
-  /** #316 – create escrow */
+  /** #316 – create escrow (no auto-retry — user explicitly triggers this) */
   create: async (payload: CreateEscrowPayload): Promise<Escrow> => {
     const { data } = await api.post<Escrow>('/api/escrows', payload);
     return data;
   },
 
-  /** #317 – release a milestone */
+  /** #317 – release a milestone (no auto-retry — tx-sensitive, user controls retry) */
   releaseMilestone: async (payload: ReleaseMilestonePayload): Promise<{ txHash: string }> => {
     const { data } = await api.post<{ txHash: string }>(
       `/api/escrows/${payload.escrowId}/milestones/${payload.milestoneId}/release`,
@@ -59,11 +64,13 @@ export const escrowApi = {
     return data;
   },
 
-  /** #317 – poll transaction status */
+  /** #317 – poll transaction status (auto-retry with longer backoff) */
   getTxStatus: async (txHash: string): Promise<{ status: string; confirmed: boolean }> => {
-    const { data } = await api.get<{ status: string; confirmed: boolean }>(
-      `/api/transactions/${txHash}/status`,
-    );
-    return data;
+    return withRetry(async () => {
+      const { data } = await api.get<{ status: string; confirmed: boolean }>(
+        `/api/transactions/${txHash}/status`,
+      );
+      return data;
+    }, { maxRetries: 2, initialDelayMs: 2000 });
   },
 };

--- a/apps/mobile/utils/errors.ts
+++ b/apps/mobile/utils/errors.ts
@@ -1,0 +1,162 @@
+/**
+ * Maps raw HTTP/network errors to user-friendly copy.
+ * Designed for testnet scenarios where endpoints can be slow or unreliable.
+ */
+
+export interface FriendlyError {
+  title: string;
+  message: string;
+  isOffline: boolean;
+  isRetryable: boolean;
+}
+
+/**
+ * Detect if an error looks like a network-offline condition.
+ */
+export function isOfflineError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+  const err = error as Record<string, unknown>;
+
+  // Classic offline signals
+  if (err.code === 'ERR_NETWORK') return true;
+  if (err.code === 'ECONNREFUSED') return true;
+  if (err.code === 'ENOTFOUND') return true;
+  if (err.code === 'ETIMEDOUT') return true;
+  if (err.code === 'ECONNRESET') return true;
+
+  // Axios timeout
+  if (err.code === 'ECONNABORTED') return true;
+
+  // No response at all = network down
+  if (!('response' in err) && ('request' in err)) return true;
+
+  return false;
+}
+
+/**
+ * Convert any error into a user-friendly message.
+ */
+export function toFriendlyError(error: unknown): FriendlyError {
+  if (!error || typeof error !== 'object') {
+    return {
+      title: 'Something went wrong',
+      message: 'An unexpected error occurred. Please try again.',
+      isOffline: false,
+      isRetryable: true,
+    };
+  }
+
+  const err = error as Record<string, unknown>;
+  const offline = isOfflineError(error);
+
+  // --- Offline / network errors ---
+  if (offline) {
+    return {
+      title: 'No internet connection',
+      message: 'It looks like you\'re offline. Check your connection and try again.',
+      isOffline: true,
+      isRetryable: true,
+    };
+  }
+
+  // --- HTTP status-based errors ---
+  const response = err.response as Record<string, unknown> | undefined;
+  if (response && typeof response === 'object' && 'status' in response) {
+    const status = response.status as number;
+    const data = response.data as Record<string, unknown> | undefined;
+    const serverMsg = data && typeof data === 'object' && 'message' in data
+      ? String(data.message)
+      : undefined;
+
+    switch (status) {
+      case 400:
+        return {
+          title: 'Invalid request',
+          message: serverMsg ?? 'The request could not be processed. Please check your input and try again.',
+          isOffline: false,
+          isRetryable: false,
+        };
+      case 401:
+        return {
+          title: 'Session expired',
+          message: 'Your session has expired. Please reconnect your wallet and try again.',
+          isOffline: false,
+          isRetryable: false,
+        };
+      case 403:
+        return {
+          title: 'Access denied',
+          message: serverMsg ?? 'You don\'t have permission to perform this action.',
+          isOffline: false,
+          isRetryable: false,
+        };
+      case 404:
+        return {
+          title: 'Not found',
+          message: 'The resource you\'re looking for doesn\'t exist or has been removed.',
+          isOffline: false,
+          isRetryable: false,
+        };
+      case 408:
+        return {
+          title: 'Request timed out',
+          message: 'The server took too long to respond. This can happen on testnet during high traffic. Please try again.',
+          isOffline: false,
+          isRetryable: true,
+        };
+      case 409:
+        return {
+          title: 'Conflict',
+          message: serverMsg ?? 'This action conflicts with the current state. Refresh and try again.',
+          isOffline: false,
+          isRetryable: true,
+        };
+      case 429:
+        return {
+          title: 'Too many requests',
+          message: 'You\'re making requests too quickly. Please wait a moment and try again.',
+          isOffline: false,
+          isRetryable: true,
+        };
+      case 500:
+        return {
+          title: 'Server error',
+          message: 'The server encountered an error. This is common on testnet. Please try again in a moment.',
+          isOffline: false,
+          isRetryable: true,
+        };
+      case 502:
+      case 503:
+      case 504:
+        return {
+          title: 'Service unavailable',
+          message: 'The network is temporarily unavailable. Testnet services can be intermittent — please try again shortly.',
+          isOffline: false,
+          isRetryable: true,
+        };
+      default:
+        if (status >= 500) {
+          return {
+            title: 'Server error',
+            message: serverMsg ?? 'Something went wrong on our end. Please try again.',
+            isOffline: false,
+            isRetryable: true,
+          };
+        }
+        return {
+          title: 'Request failed',
+          message: serverMsg ?? `Request failed (HTTP ${status}). Please try again.`,
+          isOffline: false,
+          isRetryable: status >= 400,
+        };
+    }
+  }
+
+  // --- Fallback for unknown errors ---
+  return {
+    title: 'Something went wrong',
+    message: 'An unexpected error occurred. Please try again.',
+    isOffline: false,
+    isRetryable: true,
+  };
+}

--- a/apps/mobile/utils/retry.ts
+++ b/apps/mobile/utils/retry.ts
@@ -1,0 +1,109 @@
+/**
+ * Retry utility with exponential backoff + jitter for testnet resilience.
+ *
+ * Usage:
+ *   const data = await withRetry(() => escrowApi.list({ status: 'all' }));
+ *   const data = await withRetry(() => escrowApi.getById(id), { maxRetries: 5 });
+ */
+
+export interface RetryOptions {
+  /** Maximum number of retry attempts (default: 3) */
+  maxRetries: number;
+  /** Initial delay in ms before first retry (default: 1000) */
+  initialDelayMs: number;
+  /** Maximum delay cap in ms (default: 10000) */
+  maxDelayMs: number;
+  /** Backoff multiplier (default: 2) */
+  backoffFactor: number;
+  /** Whether to add random jitter (default: true) */
+  jitter: boolean;
+  /** Predicate to decide if an error is retryable (default: isRetryableError) */
+  shouldRetry?: (error: unknown, attempt: number) => boolean;
+}
+
+const DEFAULT_OPTIONS: RetryOptions = {
+  maxRetries: 3,
+  initialDelayMs: 1000,
+  maxDelayMs: 10000,
+  backoffFactor: 2,
+  jitter: true,
+};
+
+/**
+ * Check if an error is worth retrying (network errors, 5xx, 429, timeouts).
+ */
+export function isRetryableError(error: unknown): boolean {
+  if (!error || typeof error !== 'object') return false;
+
+  const err = error as Record<string, unknown>;
+
+  // Axios timeout / network error
+  if (err.code === 'ECONNABORTED') return true;
+  if (err.code === 'ERR_NETWORK') return true;
+  if (err.code === 'ECONNRESET') return true;
+  if (err.code === 'ETIMEDOUT') return true;
+
+  // HTTP status-based
+  const response = err.response as Record<string, unknown> | undefined;
+  if (response && typeof response === 'object' && 'status' in response) {
+    const status = response.status as number;
+    // 5xx server errors, 429 rate-limit, 502/503/504 gateway
+    if (status >= 500 || status === 429 || status === 408) return true;
+  }
+
+  return false;
+}
+
+/**
+ * Compute delay with exponential backoff + optional jitter.
+ */
+function computeDelay(attempt: number, opts: RetryOptions): number {
+  const exponentialDelay = opts.initialDelayMs * Math.pow(opts.backoffFactor, attempt);
+  const cappedDelay = Math.min(exponentialDelay, opts.maxDelayMs);
+  if (opts.jitter) {
+    // Full jitter: random between 0 and cappedDelay
+    return Math.floor(Math.random() * cappedDelay);
+  }
+  return cappedDelay;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Execute an async function with automatic retry and exponential backoff.
+ *
+ * @param fn - The async function to execute
+ * @param opts - Retry configuration
+ * @returns The result of fn()
+ * @throws The last error if all retries are exhausted
+ */
+export async function withRetry<T>(
+  fn: () => Promise<T>,
+  opts: Partial<RetryOptions> = {},
+): Promise<T> {
+  const options: RetryOptions = { ...DEFAULT_OPTIONS, ...opts };
+  const shouldRetry = options.shouldRetry ?? isRetryableError;
+
+  let lastError: unknown;
+
+  for (let attempt = 0; attempt <= options.maxRetries; attempt++) {
+    try {
+      return await fn();
+    } catch (error) {
+      lastError = error;
+
+      // Don't retry if we've hit the limit or the error isn't retryable
+      if (attempt >= options.maxRetries || !shouldRetry(error, attempt)) {
+        throw error;
+      }
+
+      const delay = computeDelay(attempt, options);
+      await sleep(delay);
+    }
+  }
+
+  // Should not reach here, but TypeScript needs it
+  throw lastError;
+}


### PR DESCRIPTION
… for testnet reliability  - withRetry() utility with jittered exponential backoff and retryable predicate - getUserFacingError() maps HTTP status, network codes, JSON-RPC errors to actionable UI copy - OfflineBanner component reacts to navigator.onLine in real time - NetworkAware wrapper and useAsync hook wire everything together - ApiClient integrates retry, timeout (AbortController), and offline guard