### PR TITLE
Add dispute evidence upload pipeline

### DIFF
--- a/apps/backend/src/migrations/1774476566444-AddDisputeEvidenceFiles.ts
+++ b/apps/backend/src/migrations/1774476566444-AddDisputeEvidenceFiles.ts
@@ -1,0 +1,22 @@
+import { MigrationInterface, QueryRunner, TableColumn } from 'typeorm';
+
+export class AddDisputeEvidenceFiles1774476566444
+  implements MigrationInterface
+{
+  name = 'AddDisputeEvidenceFiles1774476566444';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.addColumn(
+      'disputes',
+      new TableColumn({
+        name: 'evidenceFiles',
+        type: 'text',
+        isNullable: true,
+      }),
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.dropColumn('disputes', 'evidenceFiles');
+  }
+}

--- a/apps/backend/src/modules/escrow/controllers/escrow.controller.ts
+++ b/apps/backend/src/modules/escrow/controllers/escrow.controller.ts
@@ -9,16 +9,16 @@ import {
   UseGuards,
   Request,
   Req,
+  Res,
   ForbiddenException,
+  BadRequestException,
   UseInterceptors,
-  UploadedFile,
-  ParseFilePipe,
-  MaxFileSizeValidator,
-  FileTypeValidator,
+  UploadedFiles,
+  StreamableFile,
 } from '@nestjs/common';
-import { FileInterceptor } from '@nestjs/platform-express';
-import { ThrottlerGuard } from '@nestjs/throttler';
-import { Request as ExpressRequest } from 'express';
+import { FileFieldsInterceptor } from '@nestjs/platform-express';
+import { Throttle, ThrottlerGuard } from '@nestjs/throttler';
+import { Request as ExpressRequest, Response } from 'express';
 import {
   ApiBearerAuth,
   ApiOkResponse,
@@ -48,6 +48,57 @@ interface AuthenticatedRequest extends ExpressRequest {
   user: { sub?: string; userId?: string; walletAddress: string };
 }
 
+interface EvidenceUploadFile {
+  buffer: Buffer;
+  originalname: string;
+  mimetype: string;
+  size: number;
+}
+
+const MAX_EVIDENCE_FILE_SIZE = 10 * 1024 * 1024;
+const MAX_EVIDENCE_FILES = 5;
+const ALLOWED_EVIDENCE_MIME_TYPES = new Set([
+  'application/pdf',
+  'image/png',
+  'image/jpg',
+  'image/jpeg',
+  'application/msword',
+  'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+]);
+const ALLOWED_EVIDENCE_EXTENSIONS = new Set([
+  'pdf',
+  'png',
+  'jpg',
+  'jpeg',
+  'doc',
+  'docx',
+]);
+
+function evidenceFileFilter(
+  _req: ExpressRequest,
+  file: { originalname: string; mimetype: string },
+  callback: (error: Error | null, acceptFile: boolean) => void,
+) {
+  const extension = file.originalname.split('.').pop()?.toLowerCase();
+  const hasAllowedExtension =
+    extension !== undefined && ALLOWED_EVIDENCE_EXTENSIONS.has(extension);
+
+  if (
+    !ALLOWED_EVIDENCE_MIME_TYPES.has(file.mimetype) ||
+    !hasAllowedExtension
+  ) {
+    callback(
+      new BadRequestException(
+        'Evidence must be a PDF, PNG, JPG, JPEG, DOC, or DOCX file',
+      ),
+      false,
+    );
+    return;
+  }
+
+  callback(null, true);
+}
+
 @Controller('escrows')
 @ApiTags('escrows')
 @ApiBearerAuth()
@@ -62,6 +113,96 @@ export class EscrowController {
     }
 
     return userId;
+  }
+
+  @Post(':id/evidence')
+  @Throttle({ default: { limit: 5, ttl: 60000 } })
+  @UseInterceptors(
+    FileFieldsInterceptor(
+      [
+        { name: 'files', maxCount: MAX_EVIDENCE_FILES },
+        { name: 'file', maxCount: MAX_EVIDENCE_FILES },
+      ],
+      {
+        limits: {
+          fileSize: MAX_EVIDENCE_FILE_SIZE,
+          files: MAX_EVIDENCE_FILES,
+        },
+        fileFilter: evidenceFileFilter,
+      },
+    ),
+  )
+  async uploadEvidence(
+    @Param('id') id: string,
+    @Request() req: AuthenticatedRequest,
+    @UploadedFiles()
+    uploadedFiles: {
+      files?: EvidenceUploadFile[];
+      file?: EvidenceUploadFile[];
+    },
+  ) {
+    uploadedFiles = uploadedFiles ?? {};
+    const files = [
+      ...(uploadedFiles.files ?? []),
+      ...(uploadedFiles.file ?? []),
+    ];
+
+    if (files.length === 0) {
+      throw new BadRequestException('At least one evidence file is required');
+    }
+
+    if (files.length > MAX_EVIDENCE_FILES) {
+      throw new BadRequestException(
+        `A maximum of ${MAX_EVIDENCE_FILES} evidence files can be uploaded`,
+      );
+    }
+
+    return this.escrowService.uploadEvidence(
+      id,
+      this.getAuthenticatedUserId(req),
+      files,
+      req.ip || req.socket?.remoteAddress,
+    );
+  }
+
+  @Get(':id/evidence')
+  async listEvidence(
+    @Param('id') id: string,
+    @Request() req: AuthenticatedRequest,
+  ) {
+    return this.escrowService.listEvidence(
+      id,
+      this.getAuthenticatedUserId(req),
+    );
+  }
+
+  @Get(':id/evidence/:cid')
+  async getEvidenceFile(
+    @Param('id') id: string,
+    @Param('cid') cid: string,
+    @Request() req: AuthenticatedRequest,
+    @Res({ passthrough: true }) res: Response,
+  ) {
+    const evidenceFile = await this.escrowService.getEvidenceFile(
+      id,
+      this.getAuthenticatedUserId(req),
+      cid,
+    );
+
+    res.setHeader(
+      'Content-Type',
+      evidenceFile.metadata.type || evidenceFile.contentType,
+    );
+    res.setHeader(
+      'Content-Disposition',
+      `inline; filename="${evidenceFile.metadata.name.replace(/"/g, '\\"')}"`,
+    );
+
+    if (evidenceFile.contentLength) {
+      res.setHeader('Content-Length', evidenceFile.contentLength.toString());
+    }
+
+    return new StreamableFile(evidenceFile.stream);
   }
 
   @Post()
@@ -304,26 +445,5 @@ export class EscrowController {
       dto,
       ipAddress,
     );
-  }
-  @Post(':id/evidence')
-  @UseGuards(EscrowAccessGuard)
-  @UseInterceptors(FileInterceptor('file'))
-  async uploadEvidence(
-    @Param('id') id: string,
-    @Request() req: AuthenticatedRequest,
-    @UploadedFile(
-      new ParseFilePipe({
-        validators: [
-          new MaxFileSizeValidator({ maxSize: 10 * 1024 * 1024 }), // 10MB
-          new FileTypeValidator({
-            fileType: /(jpg|jpeg|png|pdf|txt|doc|docx)$/,
-          }),
-        ],
-      }),
-    )
-    file: { buffer: Buffer; originalname: string },
-  ) {
-    const userId = this.getAuthenticatedUserId(req);
-    return this.escrowService.uploadEvidence(id, userId, file);
   }
 }

--- a/apps/backend/src/modules/escrow/entities/dispute.entity.ts
+++ b/apps/backend/src/modules/escrow/entities/dispute.entity.ts
@@ -23,6 +23,15 @@ export enum DisputeOutcome {
   SPLIT = 'split',
 }
 
+export interface DisputeEvidenceFile {
+  cid: string;
+  name: string;
+  type: string;
+  size: number;
+  uploadedAt: string;
+  uploadedBy: string;
+}
+
 @Entity('disputes')
 export class Dispute {
   @PrimaryGeneratedColumn('uuid')
@@ -48,6 +57,9 @@ export class Dispute {
   // Stores URLs or reference strings pointing to supporting evidence
   @Column({ type: 'simple-json', nullable: true })
   evidence: string[] | null;
+
+  @Column({ type: 'simple-json', nullable: true })
+  evidenceFiles: DisputeEvidenceFile[] | null;
 
   @Column({ type: 'varchar', default: DisputeStatus.OPEN })
   status: DisputeStatus;

--- a/apps/backend/src/modules/escrow/services/escrow.service.spec.ts
+++ b/apps/backend/src/modules/escrow/services/escrow.service.spec.ts
@@ -1,6 +1,7 @@
 import { Test, TestingModule } from '@nestjs/testing';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Repository, UpdateResult } from 'typeorm';
+import { Readable } from 'stream';
 
 import { EscrowService } from './escrow.service';
 import { Escrow, EscrowStatus, EscrowType } from '../entities/escrow.entity';
@@ -47,7 +48,11 @@ describe('EscrowService', () => {
   let userRepository: jest.Mocked<Repository<User>>;
   let assetRepository: jest.Mocked<Repository<AllowedAsset>>;
 
-  let ipfsService: { uploadFile: jest.Mock; getGatewayUrl: jest.Mock };
+  let ipfsService: {
+    uploadFile: jest.Mock;
+    getGatewayUrl: jest.Mock;
+    getFileStream: jest.Mock;
+  };
   let webhookService: { dispatchEvent: jest.Mock };
 
   // ✅ NEW MOCKS
@@ -128,6 +133,7 @@ describe('EscrowService', () => {
     const mockEventRepo = {
       create: jest.fn(),
       save: jest.fn(),
+      findOne: jest.fn(),
     };
 
     const mockDisputeRepo = {
@@ -148,6 +154,11 @@ describe('EscrowService', () => {
     const mockIpfsService = {
       uploadFile: jest.fn().mockResolvedValue('mock-cid'),
       getGatewayUrl: jest.fn().mockReturnValue('https://ipfs.io/ipfs/mock-cid'),
+      getFileStream: jest.fn().mockResolvedValue({
+        stream: Readable.from(['file-bytes']),
+        contentType: 'application/pdf',
+        contentLength: 10,
+      }),
     };
 
     // ---------------- NEW SERVICE MOCKS ----------------
@@ -247,6 +258,162 @@ describe('EscrowService', () => {
 
   it('should be defined', () => {
     expect(service).toBeDefined();
+  });
+
+  describe('dispute evidence pipeline', () => {
+    const disputedEscrow = {
+      ...mockEscrow,
+      status: EscrowStatus.DISPUTED,
+      parties: [{ ...mockParty, userId: 'seller-123' }],
+    } as Escrow;
+
+    const openDispute = {
+      id: 'dispute-123',
+      escrowId: 'escrow-123',
+      filedByUserId: 'user-123',
+      reason: 'Delivery issue',
+      evidence: null,
+      evidenceFiles: null,
+      status: DisputeStatus.OPEN,
+      createdAt: new Date('2026-01-01T00:00:00.000Z'),
+    } as Dispute;
+
+    beforeEach(() => {
+      escrowRepository.findOne.mockResolvedValue(disputedEscrow);
+      userRepository.findOne.mockResolvedValue(null);
+      eventRepository.findOne.mockResolvedValue(null);
+      eventRepository.create.mockImplementation((event) => event as EscrowEvent);
+      eventRepository.save.mockImplementation(
+        async (event) => event as EscrowEvent,
+      );
+    });
+
+    it('uploads evidence files to IPFS and appends immutable dispute metadata', async () => {
+      disputeRepository.findOne.mockResolvedValue({ ...openDispute });
+      disputeRepository.save.mockImplementation(
+        async (dispute) => dispute as Dispute,
+      );
+      ipfsService.uploadFile
+        .mockResolvedValueOnce('cid-1')
+        .mockResolvedValueOnce('cid-2');
+
+      const result = await service.uploadEvidence('escrow-123', 'user-123', [
+        {
+          buffer: Buffer.from('pdf'),
+          originalname: 'invoice.pdf',
+          mimetype: 'application/pdf',
+          size: 3,
+        },
+        {
+          buffer: Buffer.from('png'),
+          originalname: 'photo.png',
+          mimetype: 'image/png',
+          size: 3,
+        },
+      ]);
+
+      expect(ipfsService.uploadFile).toHaveBeenCalledTimes(2);
+      expect(result.cids).toEqual(['cid-1', 'cid-2']);
+      expect(disputeRepository.save).toHaveBeenCalledWith(
+        expect.objectContaining({
+          evidence: ['cid-1', 'cid-2'],
+          evidenceFiles: [
+            expect.objectContaining({
+              cid: 'cid-1',
+              name: 'invoice.pdf',
+              type: 'application/pdf',
+              size: 3,
+              uploadedBy: 'user-123',
+            }),
+            expect.objectContaining({
+              cid: 'cid-2',
+              name: 'photo.png',
+              type: 'image/png',
+              size: 3,
+              uploadedBy: 'user-123',
+            }),
+          ],
+        }),
+      );
+    });
+
+    it('lists evidence metadata for dispute parties', async () => {
+      disputeRepository.findOne.mockResolvedValue({
+        ...openDispute,
+        evidenceFiles: [
+          {
+            cid: 'cid-1',
+            name: 'invoice.pdf',
+            type: 'application/pdf',
+            size: 3,
+            uploadedAt: '2026-01-01T00:00:00.000Z',
+            uploadedBy: 'user-123',
+          },
+        ],
+      });
+
+      await expect(
+        service.listEvidence('escrow-123', 'seller-123'),
+      ).resolves.toEqual([
+        expect.objectContaining({
+          cid: 'cid-1',
+          name: 'invoice.pdf',
+        }),
+      ]);
+    });
+
+    it('streams a specific evidence file from IPFS with stored metadata', async () => {
+      disputeRepository.findOne.mockResolvedValue({
+        ...openDispute,
+        evidenceFiles: [
+          {
+            cid: 'cid-1',
+            name: 'invoice.pdf',
+            type: 'application/pdf',
+            size: 3,
+            uploadedAt: '2026-01-01T00:00:00.000Z',
+            uploadedBy: 'user-123',
+          },
+        ],
+      });
+
+      const result = await service.getEvidenceFile(
+        'escrow-123',
+        'seller-123',
+        'cid-1',
+      );
+
+      expect(ipfsService.getFileStream).toHaveBeenCalledWith('cid-1');
+      expect(result.metadata.name).toBe('invoice.pdf');
+      expect(result.contentType).toBe('application/pdf');
+    });
+
+    it('allows admins to access evidence even when they are not escrow parties', async () => {
+      userRepository.findOne.mockResolvedValue({
+        id: 'admin-123',
+        role: UserRole.ADMIN,
+      } as User);
+      disputeRepository.findOne.mockResolvedValue({
+        ...openDispute,
+        evidence: ['legacy-cid'],
+      });
+
+      await expect(
+        service.listEvidence('escrow-123', 'admin-123'),
+      ).resolves.toEqual([
+        expect.objectContaining({
+          cid: 'legacy-cid',
+          name: 'legacy-cid',
+          type: 'application/octet-stream',
+        }),
+      ]);
+    });
+
+    it('rejects evidence access for users who are neither parties nor admins', async () => {
+      await expect(
+        service.listEvidence('escrow-123', 'stranger-123'),
+      ).rejects.toBeInstanceOf(ForbiddenException);
+    });
   });
 
   // ✅ KEEP ALL YOUR EXISTING TESTS BELOW UNCHANGED

--- a/apps/backend/src/modules/escrow/services/escrow.service.ts
+++ b/apps/backend/src/modules/escrow/services/escrow.service.ts
@@ -8,6 +8,7 @@ import {
   Logger,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
+import { Readable } from 'stream';
 import {
   Brackets,
   Repository,
@@ -21,6 +22,7 @@ import { Condition } from '../entities/condition.entity';
 import { EscrowEvent, EscrowEventType } from '../entities/escrow-event.entity';
 import {
   Dispute,
+  DisputeEvidenceFile,
   DisputeStatus,
   DisputeOutcome,
 } from '../entities/dispute.entity';
@@ -55,6 +57,13 @@ import { EscrowFundingService } from '../escrow-funding.service';
 import { EscrowDisputeService } from '../escrow-dispute.service';
 import { EscrowQueryService } from '../escrow-query.service';
 import { StellarService } from '../../../services/stellar.service';
+
+interface EvidenceUploadFile {
+  buffer: Buffer;
+  originalname: string;
+  mimetype: string;
+  size: number;
+}
 
 @Injectable()
 export class EscrowService {
@@ -1125,6 +1134,7 @@ export class EscrowService {
       filedByUserId: userId,
       reason: dto.reason,
       evidence: dto.evidence ?? null,
+      evidenceFiles: this.buildAttachedCidMetadata(dto.evidence, userId),
       status: DisputeStatus.OPEN,
     });
     const savedDispute = await this.disputeRepository.save(dispute);
@@ -1535,9 +1545,23 @@ export class EscrowService {
   async uploadEvidence(
     escrowId: string,
     userId: string,
-    file: { buffer: Buffer; originalname: string },
-  ): Promise<{ cid: string; url: string }> {
-    const escrow = await this.findOne(escrowId);
+    files: EvidenceUploadFile[],
+    ipAddress?: string,
+  ): Promise<{ cids: string[]; files: DisputeEvidenceFile[] }> {
+    if (files.length === 0) {
+      throw new BadRequestException('At least one evidence file is required');
+    }
+
+    const escrow = await this.escrowRepository.findOne({
+      where: { id: escrowId },
+      relations: ['parties'],
+    });
+
+    if (!escrow) {
+      throw new NotFoundException('Escrow not found');
+    }
+
+    await this.assertEvidenceAccess(escrowId, userId);
 
     if (escrow.status !== EscrowStatus.DISPUTED) {
       throw new BadRequestException('Escrow is not in disputed status');
@@ -1551,23 +1575,143 @@ export class EscrowService {
       throw new NotFoundException('Dispute record not found');
     }
 
-    // Upload to IPFS
-    const cid = await this.ipfsService.uploadFile(
-      file.buffer,
-      file.originalname,
-    );
+    if (dispute.status === DisputeStatus.RESOLVED) {
+      throw new ConflictException('Cannot add evidence to a resolved dispute');
+    }
 
-    // Update dispute evidence list
+    const uploadedAt = new Date().toISOString();
+    const uploadedFiles: DisputeEvidenceFile[] = [];
+
+    for (const file of files) {
+      const cid = await this.ipfsService.uploadFile(
+        file.buffer,
+        file.originalname,
+      );
+
+      uploadedFiles.push({
+        cid,
+        name: file.originalname,
+        type: file.mimetype,
+        size: file.size,
+        uploadedAt,
+        uploadedBy: userId,
+      });
+    }
+
+    const existingEvidenceFiles = this.getDisputeEvidenceFiles(dispute);
     const evidence = dispute.evidence || [];
-    evidence.push(cid);
+    evidence.push(...uploadedFiles.map((file) => file.cid));
     dispute.evidence = evidence;
+    dispute.evidenceFiles = [...existingEvidenceFiles, ...uploadedFiles];
 
     await this.disputeRepository.save(dispute);
 
+    await this.logEvent(
+      escrowId,
+      EscrowEventType.UPDATED,
+      userId,
+      {
+        action: 'dispute_evidence_uploaded',
+        cids: uploadedFiles.map((file) => file.cid),
+      },
+      ipAddress,
+    );
+
     return {
-      cid,
-      url: this.ipfsService.getGatewayUrl(cid),
+      cids: uploadedFiles.map((file) => file.cid),
+      files: uploadedFiles,
     };
+  }
+
+  async listEvidence(
+    escrowId: string,
+    userId: string,
+  ): Promise<DisputeEvidenceFile[]> {
+    await this.assertEvidenceAccess(escrowId, userId);
+    const dispute = await this.getDispute(escrowId);
+
+    return this.getDisputeEvidenceFiles(dispute);
+  }
+
+  async getEvidenceFile(
+    escrowId: string,
+    userId: string,
+    cid: string,
+  ): Promise<{
+    metadata: DisputeEvidenceFile;
+    stream: Readable;
+    contentType: string;
+    contentLength?: number;
+  }> {
+    await this.assertEvidenceAccess(escrowId, userId);
+    const dispute = await this.getDispute(escrowId);
+    const metadata = this
+      .getDisputeEvidenceFiles(dispute)
+      .find((file) => file.cid === cid);
+
+    if (!metadata) {
+      throw new NotFoundException('Evidence file not found for this dispute');
+    }
+
+    const ipfsFile = await this.ipfsService.getFileStream(cid);
+
+    return {
+      metadata,
+      stream: ipfsFile.stream,
+      contentType:
+        metadata.type || ipfsFile.contentType || 'application/octet-stream',
+      contentLength: ipfsFile.contentLength,
+    };
+  }
+
+  private async assertEvidenceAccess(
+    escrowId: string,
+    userId: string,
+  ): Promise<void> {
+    const [isParty, isAdmin] = await Promise.all([
+      this.isUserPartyToEscrow(escrowId, userId),
+      this.isUserAdmin(userId),
+    ]);
+
+    if (!isParty && !isAdmin) {
+      throw new ForbiddenException(
+        'Only dispute parties and admins can access dispute evidence',
+      );
+    }
+  }
+
+  private getDisputeEvidenceFiles(dispute: Dispute): DisputeEvidenceFile[] {
+    if (dispute.evidenceFiles?.length) {
+      return dispute.evidenceFiles;
+    }
+
+    return this.buildAttachedCidMetadata(
+      dispute.evidence ?? undefined,
+      dispute.filedByUserId,
+      dispute.createdAt,
+    ) ?? [];
+  }
+
+  private buildAttachedCidMetadata(
+    cids: string[] | undefined,
+    uploadedBy: string,
+    uploadedAt: Date | string = new Date(),
+  ): DisputeEvidenceFile[] | null {
+    if (!cids?.length) {
+      return null;
+    }
+
+    const uploadedAtIso =
+      uploadedAt instanceof Date ? uploadedAt.toISOString() : uploadedAt;
+
+    return cids.map((cid) => ({
+      cid,
+      name: cid,
+      type: 'application/octet-stream',
+      size: 0,
+      uploadedAt: uploadedAtIso,
+      uploadedBy,
+    }));
   }
 
   private getErrorMessage(error: unknown): string {

--- a/apps/backend/src/modules/ipfs/ipfs.service.ts
+++ b/apps/backend/src/modules/ipfs/ipfs.service.ts
@@ -6,6 +6,7 @@ import {
 } from '@nestjs/common';
 import { ConfigType } from '@nestjs/config';
 import axios from 'axios';
+import { Readable } from 'stream';
 import ipfsConfig from '../../config/ipfs.config';
 
 interface PinataResponse {
@@ -53,6 +54,31 @@ export class IpfsService {
     } catch (error) {
       this.logger.error(`Failed to upload file to IPFS: ${filename}`, error);
       throw new InternalServerErrorException('IPFS upload failed');
+    }
+  }
+
+  async getFileStream(
+    cid: string,
+  ): Promise<{ stream: Readable; contentType?: string; contentLength?: number }> {
+    try {
+      const response = await axios.get<Readable>(this.getGatewayUrl(cid), {
+        responseType: 'stream',
+      });
+
+      const contentLength = response.headers['content-length'];
+      const contentType = response.headers['content-type'];
+
+      return {
+        stream: response.data,
+        contentType: Array.isArray(contentType) ? contentType[0] : contentType,
+        contentLength:
+          typeof contentLength === 'string'
+            ? Number.parseInt(contentLength, 10)
+            : undefined,
+      };
+    } catch (error) {
+      this.logger.error(`Failed to retrieve IPFS file: ${cid}`, error);
+      throw new InternalServerErrorException('IPFS retrieval failed');
     }
   }
 


### PR DESCRIPTION
Closes #281 

Summary:
Implemented a dispute evidence pipeline for the backend.

Added endpoints to upload, list, and retrieve dispute evidence under /escrows/:id/evidence. Uploads now accept multipart files, validate allowed evidence types, enforce size/count limits, send files to IPFS, and store returned CIDs with file metadata on the dispute record.

Also updated dispute filing so existing evidence CIDs are attached as metadata, added an evidenceFiles JSON field plus migration, added IPFS streaming support, protected evidence access for dispute parties/admins, added upload rate limiting, and wrote focused tests for the evidence flow.