### PR TITLE
feat(mobile): add in-app update prompt and version gating

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -24,3 +24,8 @@ SMTP_PORT=587
 SMTP_USER=your-smtp-user
 SMTP_PASS=your-smtp-password
 EMAIL_FROM=no-reply@vaultix.io
+
+# App Version Gating
+APP_MIN_SUPPORTED_VERSION=1.0.0
+APP_LATEST_VERSION=1.0.0
+APP_UPDATE_URL=https://apps.apple.com/app/vaultix/id0000000000

--- a/apps/backend/src/app-version/app-version.controller.ts
+++ b/apps/backend/src/app-version/app-version.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { AppVersionService, AppVersionInfo } from './app-version.service';
+
+@Controller('api/app')
+export class AppVersionController {
+  constructor(private readonly appVersionService: AppVersionService) {}
+
+  @Get('version')
+  getVersion(): AppVersionInfo {
+    return this.appVersionService.getVersionInfo();
+  }
+}

--- a/apps/backend/src/app-version/app-version.module.ts
+++ b/apps/backend/src/app-version/app-version.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { AppVersionController } from './app-version.controller';
+import { AppVersionService } from './app-version.service';
+
+@Module({
+  imports: [ConfigModule],
+  controllers: [AppVersionController],
+  providers: [AppVersionService],
+})
+export class AppVersionModule {}

--- a/apps/backend/src/app-version/app-version.service.ts
+++ b/apps/backend/src/app-version/app-version.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+export interface AppVersionInfo {
+  minSupportedVersion: string;
+  latestVersion: string;
+  updateUrl: string;
+}
+
+@Injectable()
+export class AppVersionService {
+  constructor(private readonly configService: ConfigService) {}
+
+  getVersionInfo(): AppVersionInfo {
+    return {
+      minSupportedVersion: this.configService.get<string>(
+        'APP_MIN_SUPPORTED_VERSION',
+        '1.0.0',
+      ),
+      latestVersion: this.configService.get<string>(
+        'APP_LATEST_VERSION',
+        '1.0.0',
+      ),
+      updateUrl: this.configService.get<string>(
+        'APP_UPDATE_URL',
+        'https://apps.apple.com/app/vaultix/id0000000000',
+      ),
+    };
+  }
+}

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -32,6 +32,7 @@ import { AssetsModule } from './modules/assets/assets.module';
 import { AllowedAsset } from './modules/assets/entities/allowed-asset.entity';
 import { IpfsModule } from './modules/ipfs/ipfs.module';
 import { HealthModule } from './modules/health/health.module';
+import { AppVersionModule } from './app-version/app-version.module';
 import { EscrowGateway } from './gateways/escrow.gateway';
 import stellarConfig from './config/stellar.config';
 import ipfsConfig from './config/ipfs.config';
@@ -86,6 +87,7 @@ import ipfsConfig from './config/ipfs.config';
     AssetsModule,
     IpfsModule,
     HealthModule,
+    AppVersionModule,
     JwtModule.registerAsync({
       useFactory: (configService: ConfigService) => ({
         secret:

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -3,15 +3,19 @@ import { StatusBar } from 'expo-status-bar';
 
 import { AppState, AppStateStatus } from 'react-native';
 import { useBiometricLock } from '../hooks/useBiometricLock';
+import { useAppVersion } from '../hooks/useAppVersion';
 import { MobileLockScreen } from '../components/MobileLockScreen';
-import { useEffect, useRef } from 'react';
+import { UpdatePromptModal } from '../components/UpdatePromptModal';
+import { useEffect, useRef, useState } from 'react';
 
 export default function RootLayout() {
   const { isEnabled, isUnlocked, authenticate, lock, disableBiometric } = useBiometricLock();
+  const { needsUpdate, forceUpdate, latestVersion, updateUrl, isLoading } = useAppVersion();
   const appState = useRef(AppState.currentState);
+  const [updateDismissed, setUpdateDismissed] = useState(false);
 
   useEffect(() => {
-    const subscription = AppState.addEventListener('change', nextAppState => {
+    const subscription = AppState.addEventListener('change', (nextAppState: AppStateStatus) => {
       if (
         appState.current.match(/inactive|background/) &&
         nextAppState === 'active'
@@ -30,17 +34,41 @@ export default function RootLayout() {
     };
   }, [isEnabled, authenticate, lock]);
 
-  if (!isUnlocked) {
-    return (
-      <MobileLockScreen 
-        onUnlock={authenticate} 
-        onDisableFallback={disableBiometric} 
-      />
-    );
-  }
+  // Force update: shown before biometric unlock, cannot be dismissed
+  const showForceUpdate = !isLoading && forceUpdate;
+
+  // Soft update: shown after unlock, dismissible once per session
+  const showSoftUpdate =
+    !isLoading && needsUpdate && !forceUpdate && isUnlocked && !updateDismissed;
 
   return (
     <>
+      {/* Force update gate — renders over everything including biometric lock */}
+      <UpdatePromptModal
+        visible={showForceUpdate}
+        forceUpdate={true}
+        latestVersion={latestVersion}
+        updateUrl={updateUrl}
+        onDismiss={() => {}}
+      />
+
+      {/* Biometric lock gate */}
+      {!showForceUpdate && !isUnlocked && (
+        <MobileLockScreen
+          onUnlock={authenticate}
+          onDisableFallback={disableBiometric}
+        />
+      )}
+
+      {/* Soft update prompt — shown after unlock, dismissible */}
+      <UpdatePromptModal
+        visible={showSoftUpdate}
+        forceUpdate={false}
+        latestVersion={latestVersion}
+        updateUrl={updateUrl}
+        onDismiss={() => setUpdateDismissed(true)}
+      />
+
       <StatusBar style="auto" />
       <Stack
         screenOptions={{

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -6,6 +6,7 @@ import { useBiometricLock } from '../hooks/useBiometricLock';
 import { useAppVersion } from '../hooks/useAppVersion';
 import { MobileLockScreen } from '../components/MobileLockScreen';
 import { UpdatePromptModal } from '../components/UpdatePromptModal';
+import { ToastProvider } from '../contexts/ToastProvider';
 import { useEffect, useRef, useState } from 'react';
 
 export default function RootLayout() {
@@ -42,7 +43,7 @@ export default function RootLayout() {
     !isLoading && needsUpdate && !forceUpdate && isUnlocked && !updateDismissed;
 
   return (
-    <>
+    <ToastProvider>
       {/* Force update gate — renders over everything including biometric lock */}
       <UpdatePromptModal
         visible={showForceUpdate}
@@ -89,6 +90,6 @@ export default function RootLayout() {
         <Stack.Screen name="escrow/create" options={{ title: 'Create Escrow' }} />
         <Stack.Screen name="escrow/release" options={{ title: 'Release Milestone' }} />
       </Stack>
-    </>
+    </ToastProvider>
   );
 }

--- a/apps/mobile/components/UpdatePromptModal.tsx
+++ b/apps/mobile/components/UpdatePromptModal.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import {
+  Modal,
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  Linking,
+} from 'react-native';
+
+interface UpdatePromptModalProps {
+  visible: boolean;
+  forceUpdate: boolean;
+  latestVersion: string;
+  updateUrl: string;
+  onDismiss: () => void;
+}
+
+export const UpdatePromptModal: React.FC<UpdatePromptModalProps> = ({
+  visible,
+  forceUpdate,
+  latestVersion,
+  updateUrl,
+  onDismiss,
+}) => {
+  const handleUpdate = () => {
+    Linking.openURL(updateUrl);
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      transparent={false}
+      animationType="fade"
+      onRequestClose={forceUpdate ? () => {} : onDismiss}
+    >
+      <View style={styles.container}>
+        <Text style={styles.icon}>🛡️</Text>
+
+        <Text style={styles.title}>
+          {forceUpdate ? 'Update Required' : 'Update Available'}
+        </Text>
+
+        <Text style={styles.subtitle}>
+          {forceUpdate
+            ? `Version ${latestVersion} is required to continue using Vaultix. Please update the app.`
+            : `Version ${latestVersion} of Vaultix is now available. Update for the latest features and security fixes.`}
+        </Text>
+
+        <TouchableOpacity style={styles.updateButton} onPress={handleUpdate}>
+          <Text style={styles.updateButtonText}>Update Now</Text>
+        </TouchableOpacity>
+
+        {!forceUpdate && (
+          <TouchableOpacity style={styles.laterButton} onPress={onDismiss}>
+            <Text style={styles.laterButtonText}>Later</Text>
+          </TouchableOpacity>
+        )}
+      </View>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#0F172A',
+    padding: 24,
+  },
+  icon: {
+    fontSize: 64,
+    marginBottom: 24,
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: 'bold',
+    color: '#FFFFFF',
+    marginBottom: 12,
+  },
+  subtitle: {
+    fontSize: 16,
+    color: '#94A3B8',
+    textAlign: 'center',
+    marginBottom: 48,
+    lineHeight: 24,
+  },
+  updateButton: {
+    backgroundColor: '#3B82F6',
+    paddingVertical: 14,
+    paddingHorizontal: 32,
+    borderRadius: 8,
+    width: '100%',
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  updateButtonText: {
+    color: '#FFFFFF',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  laterButton: {
+    paddingVertical: 14,
+    paddingHorizontal: 32,
+    width: '100%',
+    alignItems: 'center',
+  },
+  laterButtonText: {
+    color: '#94A3B8',
+    fontSize: 16,
+  },
+});

--- a/apps/mobile/contexts/ToastContext.tsx
+++ b/apps/mobile/contexts/ToastContext.tsx
@@ -1,0 +1,28 @@
+import React, { createContext, useContext, useState, useCallback } from 'react';
+
+export type ToastType = 'success' | 'error' | 'warning' | 'info';
+
+export interface Toast {
+  id: string;
+  message: string;
+  type: ToastType;
+  duration?: number;
+}
+
+interface ToastContextType {
+  toasts: Toast[];
+  addToast: (message: string, type: ToastType, duration?: number) => void;
+  removeToast: (id: string) => void;
+}
+
+const ToastContext = createContext<ToastContextType | undefined>(undefined);
+
+export const useToast = () => {
+  const context = useContext(ToastContext);
+  if (!context) {
+    throw new Error('useToast must be used within a ToastProvider');
+  }
+  return context;
+};
+
+export default ToastContext;

--- a/apps/mobile/contexts/ToastProvider.tsx
+++ b/apps/mobile/contexts/ToastProvider.tsx
@@ -1,0 +1,91 @@
+import React, { useState, useCallback } from 'react';
+import {
+  View,
+  Text,
+  StyleSheet,
+  Animated,
+  TouchableOpacity,
+  SafeAreaView,
+} from 'react-native';
+import ToastContext, { Toast, ToastType } from './ToastContext';
+
+const TOAST_COLORS: Record<ToastType, { bg: string; text: string; border: string }> = {
+  success: { bg: '#064E3B', text: '#6EE7B7', border: '#059669' },
+  error: { bg: '#7F1D1D', text: '#FCA5A5', border: '#DC2626' },
+  warning: { bg: '#451A03', text: '#FDE047', border: '#D97706' },
+  info: { bg: '#1E3A5F', text: '#93C5FD', border: '#3B82F6' },
+};
+
+interface ToastItemProps {
+  toast: Toast;
+  onRemove: (id: string) => void;
+}
+
+const ToastItem: React.FC<ToastItemProps> = ({ toast, onRemove }) => {
+  const colors = TOAST_COLORS[toast.type];
+  return (
+    <TouchableOpacity
+      onPress={() => onRemove(toast.id)}
+      style={[styles.toast, { backgroundColor: colors.bg, borderColor: colors.border }]}
+    >
+      <Text style={[styles.toastText, { color: colors.text }]}>{toast.message}</Text>
+    </TouchableOpacity>
+  );
+};
+
+export function ToastProvider({ children }: { children: React.ReactNode }) {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+
+  const removeToast = useCallback((id: string) => {
+    setToasts((prev) => prev.filter((t) => t.id !== id));
+  }, []);
+
+  const addToast = useCallback(
+    (message: string, type: ToastType, duration: number = 5000) => {
+      const id = Math.random().toString(36).substring(2, 9);
+      setToasts((prev) => [...prev, { id, message, type, duration }]);
+      if (duration > 0) {
+        setTimeout(() => removeToast(id), duration);
+      }
+    },
+    [removeToast],
+  );
+
+  return (
+    <ToastContext.Provider value={{ toasts, addToast, removeToast }}>
+      {children}
+      {toasts.length > 0 && (
+        <SafeAreaView style={styles.container} pointerEvents="box-none">
+          {toasts.map((t) => (
+            <ToastItem key={t.id} toast={t} onRemove={removeToast} />
+          ))}
+        </SafeAreaView>
+      )}
+    </ToastContext.Provider>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    alignItems: 'center',
+    zIndex: 9999,
+    paddingTop: 8,
+    gap: 8,
+  },
+  toast: {
+    marginHorizontal: 16,
+    paddingVertical: 12,
+    paddingHorizontal: 16,
+    borderRadius: 8,
+    borderWidth: 1,
+    width: '90%',
+  },
+  toastText: {
+    fontSize: 14,
+    fontWeight: '500',
+  },
+});

--- a/apps/mobile/hooks/useAppVersion.ts
+++ b/apps/mobile/hooks/useAppVersion.ts
@@ -1,0 +1,72 @@
+import { useState, useEffect } from 'react';
+import Constants from 'expo-constants';
+import { versionApi, AppVersionResponse } from '../services/api';
+
+const MIN_SUPPORTED_VERSION_FALLBACK = '1.0.0';
+const LATEST_VERSION_FALLBACK = '1.0.0';
+const UPDATE_URL_FALLBACK = 'https://apps.apple.com/app/vaultix/id0000000000';
+
+function compareSemver(a: string, b: string): number {
+  const parse = (v: string) => v.split('.').map(n => parseInt(n, 10) || 0);
+  const [aMaj, aMin, aPatch] = parse(a);
+  const [bMaj, bMin, bPatch] = parse(b);
+  if (aMaj !== bMaj) return aMaj - bMaj;
+  if (aMin !== bMin) return aMin - bMin;
+  return aPatch - bPatch;
+}
+
+export interface AppVersionState {
+  needsUpdate: boolean;
+  forceUpdate: boolean;
+  latestVersion: string;
+  updateUrl: string;
+  isLoading: boolean;
+}
+
+export const useAppVersion = (): AppVersionState => {
+  const currentVersion = Constants.expoConfig?.version ?? '1.0.0';
+
+  const [state, setState] = useState<AppVersionState>({
+    needsUpdate: false,
+    forceUpdate: false,
+    latestVersion: LATEST_VERSION_FALLBACK,
+    updateUrl: UPDATE_URL_FALLBACK,
+    isLoading: true,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const checkVersion = async () => {
+      let info: AppVersionResponse;
+      try {
+        info = await versionApi.check();
+      } catch {
+        // On network/server failure use safe fallback — never block user due to backend outage
+        info = {
+          minSupportedVersion: MIN_SUPPORTED_VERSION_FALLBACK,
+          latestVersion: LATEST_VERSION_FALLBACK,
+          updateUrl: UPDATE_URL_FALLBACK,
+        };
+      }
+
+      if (cancelled) return;
+
+      const isBelowMin = compareSemver(currentVersion, info.minSupportedVersion) < 0;
+      const isBelowLatest = compareSemver(currentVersion, info.latestVersion) < 0;
+
+      setState({
+        needsUpdate: isBelowLatest,
+        forceUpdate: isBelowMin,
+        latestVersion: info.latestVersion,
+        updateUrl: info.updateUrl,
+        isLoading: false,
+      });
+    };
+
+    checkVersion();
+    return () => { cancelled = true; };
+  }, [currentVersion]);
+
+  return state;
+};

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -22,7 +22,9 @@
     "axios": "^1.7.9",
     "expo-local-authentication": "~15.0.1",
     "expo-secure-store": "~14.0.0",
-    "expo-constants": "~17.0.0"
+    "expo-constants": "~17.0.0",
+    "expo-clipboard": "~7.0.0",
+    "@react-native-community/netinfo": "^11.4.1"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -21,7 +21,8 @@
     "react-native-screens": "~4.4.0",
     "axios": "^1.7.9",
     "expo-local-authentication": "~15.0.1",
-    "expo-secure-store": "~14.0.0"
+    "expo-secure-store": "~14.0.0",
+    "expo-constants": "~17.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/apps/mobile/services/api.ts
+++ b/apps/mobile/services/api.ts
@@ -87,6 +87,20 @@ export const inviteApi = {
   },
 };
 
+export interface AppVersionResponse {
+  minSupportedVersion: string;
+  latestVersion: string;
+  updateUrl: string;
+}
+
+export const versionApi = {
+  /** #366 – check minimum supported and latest app versions */
+  check: async (): Promise<AppVersionResponse> => {
+    const { data } = await api.get<AppVersionResponse>('/api/app/version');
+    return data;
+  },
+};
+
 export const notificationApi = {
   /** Fetch user notifications */
   list: async (): Promise<NotificationsResponse> => {


### PR DESCRIPTION
- Add GET /api/app/version backend endpoint (AppVersionModule) driven by APP_MIN_SUPPORTED_VERSION / APP_LATEST_VERSION / APP_UPDATE_URL env vars
- Add useAppVersion hook with semver comparison and safe network-failure fallback
- Add UpdatePromptModal component: blocking (no dismiss) for force updates, dismissible for soft updates; matches existing dark-theme style
- Integrate into _layout.tsx so force-update renders before biometric unlock, soft-update renders after unlock once per session

Closes #366