### PR TITLE
feat(mobile): in-app update prompt and version gating

### DIFF
--- a/apps/backend/.env.example
+++ b/apps/backend/.env.example
@@ -24,3 +24,8 @@ SMTP_PORT=587
 SMTP_USER=your-smtp-user
 SMTP_PASS=your-smtp-password
 EMAIL_FROM=no-reply@vaultix.io
+
+# App Version Gating
+APP_MIN_SUPPORTED_VERSION=1.0.0
+APP_LATEST_VERSION=1.0.0
+APP_UPDATE_URL=https://apps.apple.com/app/vaultix/id0000000000

--- a/apps/backend/src/app-version/app-version.controller.ts
+++ b/apps/backend/src/app-version/app-version.controller.ts
@@ -1,0 +1,12 @@
+import { Controller, Get } from '@nestjs/common';
+import { AppVersionService, AppVersionInfo } from './app-version.service';
+
+@Controller('api/app')
+export class AppVersionController {
+  constructor(private readonly appVersionService: AppVersionService) {}
+
+  @Get('version')
+  getVersion(): AppVersionInfo {
+    return this.appVersionService.getVersionInfo();
+  }
+}

--- a/apps/backend/src/app-version/app-version.module.ts
+++ b/apps/backend/src/app-version/app-version.module.ts
@@ -1,0 +1,11 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { AppVersionController } from './app-version.controller';
+import { AppVersionService } from './app-version.service';
+
+@Module({
+  imports: [ConfigModule],
+  controllers: [AppVersionController],
+  providers: [AppVersionService],
+})
+export class AppVersionModule {}

--- a/apps/backend/src/app-version/app-version.service.ts
+++ b/apps/backend/src/app-version/app-version.service.ts
@@ -1,0 +1,30 @@
+import { Injectable } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+export interface AppVersionInfo {
+  minSupportedVersion: string;
+  latestVersion: string;
+  updateUrl: string;
+}
+
+@Injectable()
+export class AppVersionService {
+  constructor(private readonly configService: ConfigService) {}
+
+  getVersionInfo(): AppVersionInfo {
+    return {
+      minSupportedVersion: this.configService.get<string>(
+        'APP_MIN_SUPPORTED_VERSION',
+        '1.0.0',
+      ),
+      latestVersion: this.configService.get<string>(
+        'APP_LATEST_VERSION',
+        '1.0.0',
+      ),
+      updateUrl: this.configService.get<string>(
+        'APP_UPDATE_URL',
+        'https://apps.apple.com/app/vaultix/id0000000000',
+      ),
+    };
+  }
+}

--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -32,6 +32,7 @@ import { AssetsModule } from './modules/assets/assets.module';
 import { AllowedAsset } from './modules/assets/entities/allowed-asset.entity';
 import { IpfsModule } from './modules/ipfs/ipfs.module';
 import { HealthModule } from './modules/health/health.module';
+import { AppVersionModule } from './app-version/app-version.module';
 import { EscrowGateway } from './gateways/escrow.gateway';
 import stellarConfig from './config/stellar.config';
 import ipfsConfig from './config/ipfs.config';
@@ -86,6 +87,7 @@ import ipfsConfig from './config/ipfs.config';
     AssetsModule,
     IpfsModule,
     HealthModule,
+    AppVersionModule,
     JwtModule.registerAsync({
       useFactory: (configService: ConfigService) => ({
         secret:

--- a/apps/mobile/app/_layout.tsx
+++ b/apps/mobile/app/_layout.tsx
@@ -4,15 +4,19 @@ import { ToastProvider } from '../components/Toast';
 
 import { AppState, AppStateStatus } from 'react-native';
 import { useBiometricLock } from '../hooks/useBiometricLock';
+import { useAppVersion } from '../hooks/useAppVersion';
 import { MobileLockScreen } from '../components/MobileLockScreen';
-import { useEffect, useRef } from 'react';
+import { UpdatePromptModal } from '../components/UpdatePromptModal';
+import { useEffect, useRef, useState } from 'react';
 
 export default function RootLayout() {
   const { isEnabled, isUnlocked, authenticate, lock, disableBiometric } = useBiometricLock();
+  const { needsUpdate, forceUpdate, latestVersion, updateUrl, isLoading } = useAppVersion();
   const appState = useRef(AppState.currentState);
+  const [updateDismissed, setUpdateDismissed] = useState(false);
 
   useEffect(() => {
-    const subscription = AppState.addEventListener('change', nextAppState => {
+    const subscription = AppState.addEventListener('change', (nextAppState: AppStateStatus) => {
       if (
         appState.current.match(/inactive|background/) &&
         nextAppState === 'active'
@@ -31,17 +35,41 @@ export default function RootLayout() {
     };
   }, [isEnabled, authenticate, lock]);
 
-  if (!isUnlocked) {
-    return (
-      <MobileLockScreen 
-        onUnlock={authenticate} 
-        onDisableFallback={disableBiometric} 
-      />
-    );
-  }
+  // Force update: shown before biometric unlock, cannot be dismissed
+  const showForceUpdate = !isLoading && forceUpdate;
+
+  // Soft update: shown after unlock, dismissible once per session
+  const showSoftUpdate =
+    !isLoading && needsUpdate && !forceUpdate && isUnlocked && !updateDismissed;
 
   return (
     <ToastProvider>
+      {/* Force update gate — renders over everything including biometric lock */}
+      <UpdatePromptModal
+        visible={showForceUpdate}
+        forceUpdate={true}
+        latestVersion={latestVersion}
+        updateUrl={updateUrl}
+        onDismiss={() => {}}
+      />
+
+      {/* Biometric lock gate */}
+      {!showForceUpdate && !isUnlocked && (
+        <MobileLockScreen
+          onUnlock={authenticate}
+          onDisableFallback={disableBiometric}
+        />
+      )}
+
+      {/* Soft update prompt — shown after unlock, dismissible */}
+      <UpdatePromptModal
+        visible={showSoftUpdate}
+        forceUpdate={false}
+        latestVersion={latestVersion}
+        updateUrl={updateUrl}
+        onDismiss={() => setUpdateDismissed(true)}
+      />
+
       <StatusBar style="auto" />
       <Stack
         screenOptions={{

--- a/apps/mobile/components/UpdatePromptModal.tsx
+++ b/apps/mobile/components/UpdatePromptModal.tsx
@@ -1,0 +1,113 @@
+import React from 'react';
+import {
+  Modal,
+  View,
+  Text,
+  TouchableOpacity,
+  StyleSheet,
+  Linking,
+} from 'react-native';
+
+interface UpdatePromptModalProps {
+  visible: boolean;
+  forceUpdate: boolean;
+  latestVersion: string;
+  updateUrl: string;
+  onDismiss: () => void;
+}
+
+export const UpdatePromptModal: React.FC<UpdatePromptModalProps> = ({
+  visible,
+  forceUpdate,
+  latestVersion,
+  updateUrl,
+  onDismiss,
+}) => {
+  const handleUpdate = () => {
+    Linking.openURL(updateUrl);
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      transparent={false}
+      animationType="fade"
+      onRequestClose={forceUpdate ? () => {} : onDismiss}
+    >
+      <View style={styles.container}>
+        <Text style={styles.icon}>🛡️</Text>
+
+        <Text style={styles.title}>
+          {forceUpdate ? 'Update Required' : 'Update Available'}
+        </Text>
+
+        <Text style={styles.subtitle}>
+          {forceUpdate
+            ? `Version ${latestVersion} is required to continue using Vaultix. Please update the app.`
+            : `Version ${latestVersion} of Vaultix is now available. Update for the latest features and security fixes.`}
+        </Text>
+
+        <TouchableOpacity style={styles.updateButton} onPress={handleUpdate}>
+          <Text style={styles.updateButtonText}>Update Now</Text>
+        </TouchableOpacity>
+
+        {!forceUpdate && (
+          <TouchableOpacity style={styles.laterButton} onPress={onDismiss}>
+            <Text style={styles.laterButtonText}>Later</Text>
+          </TouchableOpacity>
+        )}
+      </View>
+    </Modal>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    justifyContent: 'center',
+    alignItems: 'center',
+    backgroundColor: '#0F172A',
+    padding: 24,
+  },
+  icon: {
+    fontSize: 64,
+    marginBottom: 24,
+  },
+  title: {
+    fontSize: 28,
+    fontWeight: 'bold',
+    color: '#FFFFFF',
+    marginBottom: 12,
+  },
+  subtitle: {
+    fontSize: 16,
+    color: '#94A3B8',
+    textAlign: 'center',
+    marginBottom: 48,
+    lineHeight: 24,
+  },
+  updateButton: {
+    backgroundColor: '#3B82F6',
+    paddingVertical: 14,
+    paddingHorizontal: 32,
+    borderRadius: 8,
+    width: '100%',
+    alignItems: 'center',
+    marginBottom: 16,
+  },
+  updateButtonText: {
+    color: '#FFFFFF',
+    fontSize: 16,
+    fontWeight: '600',
+  },
+  laterButton: {
+    paddingVertical: 14,
+    paddingHorizontal: 32,
+    width: '100%',
+    alignItems: 'center',
+  },
+  laterButtonText: {
+    color: '#94A3B8',
+    fontSize: 16,
+  },
+});

--- a/apps/mobile/hooks/useAppVersion.ts
+++ b/apps/mobile/hooks/useAppVersion.ts
@@ -1,0 +1,72 @@
+import { useState, useEffect } from 'react';
+import Constants from 'expo-constants';
+import { versionApi, AppVersionResponse } from '../services/api';
+
+const MIN_SUPPORTED_VERSION_FALLBACK = '1.0.0';
+const LATEST_VERSION_FALLBACK = '1.0.0';
+const UPDATE_URL_FALLBACK = 'https://apps.apple.com/app/vaultix/id0000000000';
+
+function compareSemver(a: string, b: string): number {
+  const parse = (v: string) => v.split('.').map(n => parseInt(n, 10) || 0);
+  const [aMaj, aMin, aPatch] = parse(a);
+  const [bMaj, bMin, bPatch] = parse(b);
+  if (aMaj !== bMaj) return aMaj - bMaj;
+  if (aMin !== bMin) return aMin - bMin;
+  return aPatch - bPatch;
+}
+
+export interface AppVersionState {
+  needsUpdate: boolean;
+  forceUpdate: boolean;
+  latestVersion: string;
+  updateUrl: string;
+  isLoading: boolean;
+}
+
+export const useAppVersion = (): AppVersionState => {
+  const currentVersion = Constants.expoConfig?.version ?? '1.0.0';
+
+  const [state, setState] = useState<AppVersionState>({
+    needsUpdate: false,
+    forceUpdate: false,
+    latestVersion: LATEST_VERSION_FALLBACK,
+    updateUrl: UPDATE_URL_FALLBACK,
+    isLoading: true,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const checkVersion = async () => {
+      let info: AppVersionResponse;
+      try {
+        info = await versionApi.check();
+      } catch {
+        // On network/server failure use safe fallback — never block user due to backend outage
+        info = {
+          minSupportedVersion: MIN_SUPPORTED_VERSION_FALLBACK,
+          latestVersion: LATEST_VERSION_FALLBACK,
+          updateUrl: UPDATE_URL_FALLBACK,
+        };
+      }
+
+      if (cancelled) return;
+
+      const isBelowMin = compareSemver(currentVersion, info.minSupportedVersion) < 0;
+      const isBelowLatest = compareSemver(currentVersion, info.latestVersion) < 0;
+
+      setState({
+        needsUpdate: isBelowLatest,
+        forceUpdate: isBelowMin,
+        latestVersion: info.latestVersion,
+        updateUrl: info.updateUrl,
+        isLoading: false,
+      });
+    };
+
+    checkVersion();
+    return () => { cancelled = true; };
+  }, [currentVersion]);
+
+  return state;
+};

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -20,13 +20,11 @@
     "react-native-safe-area-context": "4.12.0",
     "react-native-screens": "~4.4.0",
     "axios": "^1.7.9",
-<<<<<<< HEAD
-    "expo-clipboard": "~7.0.0",
-    "@react-native-community/netinfo": "^11.4.1"
-=======
     "expo-local-authentication": "~15.0.1",
-    "expo-secure-store": "~14.0.0"
->>>>>>> d431ba40ce53cfcf510d9b702e2540ee53b1f9f1
+    "expo-secure-store": "~14.0.0",
+    "expo-clipboard": "~7.0.0",
+    "@react-native-community/netinfo": "^11.4.1",
+    "expo-constants": "~17.0.0"
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",

--- a/apps/mobile/services/api.ts
+++ b/apps/mobile/services/api.ts
@@ -6,11 +6,8 @@ import {
   CreateEscrowPayload,
   ReleaseMilestonePayload,
 } from '../types/escrow';
-<<<<<<< HEAD
 import { withRetry } from '../utils/retry';
-=======
 import { Notification, NotificationsResponse } from '../types/notification';
->>>>>>> d431ba40ce53cfcf510d9b702e2540ee53b1f9f1
 
 const API_BASE_URL = process.env.EXPO_PUBLIC_API_BASE_URL ?? 'http://localhost:3000';
 
@@ -43,7 +40,7 @@ export const escrowApi = {
 
       const { data } = await api.get<EscrowListResponse>('/api/escrows', { params });
       return data;
-    }, { maxRetries: 2 }); // Lighter retry for list calls to avoid stale data
+    }, { maxRetries: 2 });
   },
 
   /** #315 – get single escrow with milestones, parties, events (auto-retry) */
@@ -93,6 +90,20 @@ export const inviteApi = {
   },
   acceptInvitation: async (token: string): Promise<InviteValidation> => {
     const { data } = await api.post<InviteValidation>(`/api/invites/${token}/accept`);
+    return data;
+  },
+};
+
+export interface AppVersionResponse {
+  minSupportedVersion: string;
+  latestVersion: string;
+  updateUrl: string;
+}
+
+export const versionApi = {
+  /** #366 – check minimum supported and latest app versions */
+  check: async (): Promise<AppVersionResponse> => {
+    const { data } = await api.get<AppVersionResponse>('/api/app/version');
     return data;
   },
 };


### PR DESCRIPTION
- Add GET /api/app/version backend endpoint (AppVersionModule) driven by APP_MIN_SUPPORTED_VERSION / APP_LATEST_VERSION / APP_UPDATE_URL env vars
- Add useAppVersion hook with semver comparison and safe network-failure fallback
- Add UpdatePromptModal: blocking for force updates, dismissible for soft updates
- Integrate into _layout.tsx; force update renders before biometric unlock, soft update renders after unlock once per session
- Fix pre-existing conflict markers in package.json and api.ts from main
- Add expo-constants to mobile dependencies

Closes #366