### PR TITLE
feat(backend): implement webhook registration, delivery, and retry handling

### DIFF
--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -25,6 +25,7 @@ import { NotificationPreference } from './notifications/entities/notification-pr
 import { ApiKey } from './api-key/entities/api-key.entity';
 import { AdminAuditLog } from './modules/admin/entities/admin-audit-log.entity';
 import { Webhook } from './modules/webhook/webhook.entity';
+import { WebhookDelivery } from './modules/webhook/webhook-delivery.entity';
 import { StellarEvent } from './modules/stellar/entities/stellar-event.entity';
 import { AdminModule } from './modules/admin/admin.module';
 import { StellarEventModule } from './modules/stellar/stellar-event.module';
@@ -66,6 +67,7 @@ import ipfsConfig from './config/ipfs.config';
           ApiKey,
           AdminAuditLog,
           Webhook,
+          WebhookDelivery,
           StellarEvent,
           AllowedAsset,
         ],

--- a/apps/backend/src/data-source.ts
+++ b/apps/backend/src/data-source.ts
@@ -12,6 +12,7 @@ import { NotificationPreference } from './notifications/entities/notification-pr
 import { ApiKey } from './api-key/entities/api-key.entity';
 import { AdminAuditLog } from './modules/admin/entities/admin-audit-log.entity';
 import { Webhook } from './modules/webhook/webhook.entity';
+import { WebhookDelivery } from './modules/webhook/webhook-delivery.entity';
 import { StellarEvent } from './modules/stellar/entities/stellar-event.entity';
 import { AllowedAsset } from './modules/assets/entities/allowed-asset.entity';
 
@@ -33,6 +34,7 @@ export default new DataSource({
     ApiKey,
     AdminAuditLog,
     Webhook,
+    WebhookDelivery,
     StellarEvent,
     AllowedAsset,
   ],

--- a/apps/backend/src/migrations/1774364376000-AddWebhookDeliverySystem.ts
+++ b/apps/backend/src/migrations/1774364376000-AddWebhookDeliverySystem.ts
@@ -1,0 +1,35 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddWebhookDeliverySystem1774364376000 implements MigrationInterface {
+  name = 'AddWebhookDeliverySystem1774364376000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `ALTER TABLE "webhooks" ADD COLUMN "failureCount" integer NOT NULL DEFAULT (0)`,
+    );
+    await queryRunner.query(
+      `ALTER TABLE "webhooks" ADD COLUMN "lastTriggeredAt" datetime`,
+    );
+
+    await queryRunner.query(`
+      CREATE TABLE "webhook_deliveries" (
+        "id" varchar PRIMARY KEY NOT NULL,
+        "event" varchar NOT NULL,
+        "payload" text,
+        "responseStatus" integer,
+        "attemptCount" integer NOT NULL DEFAULT (0),
+        "nextRetryAt" datetime,
+        "createdAt" datetime NOT NULL DEFAULT (datetime('now')),
+        "updatedAt" datetime NOT NULL DEFAULT (datetime('now')),
+        "webhookId" varchar,
+        CONSTRAINT "FK_webhook_delivery_webhook" FOREIGN KEY ("webhookId") REFERENCES "webhooks" ("id") ON DELETE CASCADE
+      )
+    `);
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP TABLE "webhook_deliveries"`);
+    await queryRunner.query(`ALTER TABLE "webhooks" DROP COLUMN "lastTriggeredAt"`);
+    await queryRunner.query(`ALTER TABLE "webhooks" DROP COLUMN "failureCount"`);
+  }
+}

--- a/apps/backend/src/modules/webhook/webhook-delivery.entity.ts
+++ b/apps/backend/src/modules/webhook/webhook-delivery.entity.ts
@@ -1,0 +1,42 @@
+import {
+  Column,
+  CreateDateColumn,
+  Entity,
+  ManyToOne,
+  PrimaryGeneratedColumn,
+  UpdateDateColumn,
+} from 'typeorm';
+import { Webhook } from './webhook.entity';
+import type { WebhookEvent } from '../../types/webhook/webhook.types';
+
+@Entity('webhook_deliveries')
+export class WebhookDelivery {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @ManyToOne(() => Webhook, (webhook) => webhook.deliveries, {
+    onDelete: 'CASCADE',
+  })
+  webhook: Webhook;
+
+  @Column()
+  event: WebhookEvent | string;
+
+  @Column({ type: 'simple-json', nullable: true })
+  payload?: Record<string, unknown> | null;
+
+  @Column({ type: 'int', nullable: true })
+  responseStatus?: number | null;
+
+  @Column({ default: 0 })
+  attemptCount: number;
+
+  @Column({ type: 'datetime', nullable: true })
+  nextRetryAt?: Date | null;
+
+  @CreateDateColumn()
+  createdAt: Date;
+
+  @UpdateDateColumn()
+  updatedAt: Date;
+}

--- a/apps/backend/src/modules/webhook/webhook.controller.ts
+++ b/apps/backend/src/modules/webhook/webhook.controller.ts
@@ -3,11 +3,11 @@ import {
   Post,
   Get,
   Delete,
+  Patch,
   Body,
   Param,
   Req,
   UseGuards,
-  UseInterceptors,
 } from '@nestjs/common';
 import { WebhookService } from '../../services/webhook/webhook.service';
 import { WebhookEvent } from '../../types/webhook/webhook.types';
@@ -16,8 +16,14 @@ import { ThrottlerGuard } from '@nestjs/throttler';
 
 class CreateWebhookDto {
   url: string;
-  secret: string;
+  secret?: string;
   events: WebhookEvent[];
+}
+
+class UpdateWebhookDto {
+  url?: string;
+  events?: WebhookEvent[];
+  isActive?: boolean;
 }
 
 @Controller('webhooks')
@@ -26,7 +32,7 @@ export class WebhookController {
   constructor(private readonly webhookService: WebhookService) {}
 
   @Post()
-  @UseInterceptors(ThrottlerGuard)
+  @UseGuards(ThrottlerGuard)
   async create(
     @Req() req: { user: { id: string } },
     @Body() dto: CreateWebhookDto,
@@ -46,6 +52,38 @@ export class WebhookController {
     const userId = req?.user?.id;
     if (!userId) throw new Error('User ID missing');
     return this.webhookService.getUserWebhooks(userId);
+  }
+
+  @Patch(':id')
+  async update(
+    @Req() req: { user: { id: string } },
+    @Param('id') id: string,
+    @Body() dto: UpdateWebhookDto,
+  ) {
+    const userId = req?.user?.id;
+    if (!userId) throw new Error('User ID missing');
+    return this.webhookService.updateWebhook(userId, id, dto);
+  }
+
+  @Get(':id/deliveries')
+  async deliveries(@Req() req: { user: { id: string } }, @Param('id') id: string) {
+    const userId = req?.user?.id;
+    if (!userId) throw new Error('User ID missing');
+    return this.webhookService.getWebhookDeliveries(userId, id);
+  }
+
+  @Post(':id/retry')
+  async retry(@Req() req: { user: { id: string } }, @Param('id') id: string) {
+    const userId = req?.user?.id;
+    if (!userId) throw new Error('User ID missing');
+    return this.webhookService.retryWebhookDelivery(userId, id);
+  }
+
+  @Post(':id/test')
+  async test(@Req() req: { user: { id: string } }, @Param('id') id: string) {
+    const userId = req?.user?.id;
+    if (!userId) throw new Error('User ID missing');
+    return this.webhookService.testWebhook(userId, id);
   }
 
   @Delete(':id')

--- a/apps/backend/src/modules/webhook/webhook.entity.ts
+++ b/apps/backend/src/modules/webhook/webhook.entity.ts
@@ -3,10 +3,12 @@ import {
   Entity,
   PrimaryGeneratedColumn,
   ManyToOne,
+  OneToMany,
   CreateDateColumn,
   UpdateDateColumn,
 } from 'typeorm';
 import { User } from '../user/entities/user.entity';
+import { WebhookDelivery } from './webhook-delivery.entity';
 import type { WebhookEvent } from '../../types/webhook/webhook.types';
 
 @Entity('webhooks')
@@ -26,8 +28,19 @@ export class Webhook {
   @Column({ default: true })
   isActive: boolean;
 
+  @Column({ type: 'int', default: 0 })
+  failureCount: number;
+
+  @Column({ type: 'datetime', nullable: true })
+  lastTriggeredAt?: Date | null;
+
   @ManyToOne(() => User, { nullable: false })
   user: User;
+
+  @OneToMany(() => WebhookDelivery, (delivery) => delivery.webhook, {
+    cascade: true,
+  })
+  deliveries: WebhookDelivery[];
 
   @CreateDateColumn()
   createdAt: Date;

--- a/apps/backend/src/modules/webhook/webhook.module.ts
+++ b/apps/backend/src/modules/webhook/webhook.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from '../auth/auth.module';
 import { Webhook } from './webhook.entity';
+import { WebhookDelivery } from './webhook-delivery.entity';
 import { WebhookService } from '../../services/webhook/webhook.service';
 import { WebhookController } from './webhook.controller';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Webhook]), AuthModule],
+  imports: [TypeOrmModule.forFeature([Webhook, WebhookDelivery]), AuthModule],
   providers: [WebhookService],
   controllers: [WebhookController],
   exports: [WebhookService],

--- a/apps/backend/src/services/webhook/webhook.service.spec.ts
+++ b/apps/backend/src/services/webhook/webhook.service.spec.ts
@@ -2,6 +2,7 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { WebhookService } from './webhook.service';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Webhook } from '../../modules/webhook/webhook.entity';
+import { WebhookDelivery } from '../../modules/webhook/webhook-delivery.entity';
 import { Repository } from 'typeorm';
 import axios from 'axios';
 import { WebhookEvent } from '../../types/webhook/webhook.types';
@@ -17,6 +18,7 @@ const mockedAxios = axios as jest.Mocked<typeof axios>;
 describe('WebhookService', () => {
   let service: WebhookService;
   let repo: jest.Mocked<Repository<Webhook>>;
+  let deliveryRepo: jest.Mocked<Repository<WebhookDelivery>>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -30,6 +32,18 @@ describe('WebhookService', () => {
             create: jest.fn(),
             save: jest.fn(),
             delete: jest.fn(),
+            update: jest.fn(),
+          },
+        },
+        {
+          provide: getRepositoryToken(WebhookDelivery),
+          useValue: {
+            find: jest.fn(),
+            findOne: jest.fn(),
+            create: jest.fn(),
+            save: jest.fn(),
+            delete: jest.fn(),
+            update: jest.fn(),
           },
         },
       ],
@@ -37,12 +51,13 @@ describe('WebhookService', () => {
 
     service = module.get<WebhookService>(WebhookService);
     repo = module.get(getRepositoryToken(Webhook));
+    deliveryRepo = module.get(getRepositoryToken(WebhookDelivery));
   });
 
   const mockWebhook = {
     id: 'w1',
     user: { id: 'u1' },
-    url: 'http://test.com',
+    url: 'https://test.com',
     secret: 'test-secret',
     events: ['escrow.created'],
     isActive: true,
@@ -54,7 +69,7 @@ describe('WebhookService', () => {
       repo.create.mockReturnValue(mockWebhook as any);
       repo.save.mockResolvedValue(mockWebhook as any);
 
-      const result = await service.createWebhook('u1', 'test.com', 'secret', [
+      const result = await service.createWebhook('u1', 'https://test.com', 'secret', [
         'escrow.created',
       ]);
 
@@ -62,11 +77,25 @@ describe('WebhookService', () => {
       expect(result).toEqual(mockWebhook);
     });
 
+    it('should generate a signing secret when none is provided', async () => {
+      repo.find.mockResolvedValue([]);
+      repo.create.mockReturnValue(mockWebhook as any);
+      repo.save.mockResolvedValue(mockWebhook as any);
+
+      await service.createWebhook('u1', 'https://test.com', undefined as any, [
+        'escrow.created',
+      ]);
+
+      expect(repo.create).toHaveBeenCalledWith(
+        expect.objectContaining({ secret: expect.any(String) }),
+      );
+    });
+
     it('should throw if too many events', async () => {
       await expect(
         service.createWebhook(
           'u1',
-          'test.com',
+          'https://test.com',
           'secret',
           Array(10).fill('escrow.created') as any,
         ),
@@ -76,7 +105,7 @@ describe('WebhookService', () => {
     it('should throw if user exceeds webhook limit', async () => {
       repo.find.mockResolvedValue(Array(11).fill(mockWebhook) as any);
       await expect(
-        service.createWebhook('u1', 'test.com', 'secret', ['escrow.created']),
+        service.createWebhook('u1', 'https://test.com', 'secret', ['escrow.created']),
       ).rejects.toThrow(UnprocessableEntityException);
     });
   });
@@ -149,6 +178,17 @@ describe('WebhookService', () => {
         expect.anything(),
         2,
       );
+    });
+  });
+
+  describe('deliveries', () => {
+    it('should return deliveries for a webhook owned by the user', async () => {
+      repo.findOne.mockResolvedValue(mockWebhook as any);
+      deliveryRepo.find.mockResolvedValue([{ id: 'd1' }] as any);
+
+      const result = await service.getWebhookDeliveries('u1', 'w1');
+
+      expect(result).toHaveLength(1);
     });
   });
 

--- a/apps/backend/src/services/webhook/webhook.service.ts
+++ b/apps/backend/src/services/webhook/webhook.service.ts
@@ -5,10 +5,12 @@ import {
   Logger,
   OnModuleDestroy,
   UnprocessableEntityException,
+  BadRequestException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Repository } from 'typeorm';
 import { Webhook } from '../../modules/webhook/webhook.entity';
+import { WebhookDelivery } from '../../modules/webhook/webhook-delivery.entity';
 import {
   WebhookEvent,
   WebhookPayload,
@@ -22,10 +24,14 @@ export class WebhookService implements OnModuleDestroy {
   private timeouts: Map<string, NodeJS.Timeout> = new Map();
   private readonly MAX_WEBHOOKS_PER_USER = 10;
   private readonly MAX_EVENTS_PER_WEBHOOK = 8;
+  private readonly MAX_FAILURES = 5;
+  private readonly RETRY_DELAYS_MS = [60_000, 300_000, 1_800_000, 7_200_000, 43_200_000];
 
   constructor(
     @InjectRepository(Webhook)
     private readonly webhookRepo: Repository<Webhook>,
+    @InjectRepository(WebhookDelivery)
+    private readonly deliveryRepo: Repository<WebhookDelivery>,
   ) {}
 
   onModuleDestroy() {
@@ -41,7 +47,12 @@ export class WebhookService implements OnModuleDestroy {
     secret: string,
     events: WebhookEvent[],
   ): Promise<Webhook> {
-    // Check maximum events per webhook
+    this.validateWebhookUrl(url);
+
+    if (!events?.length) {
+      throw new BadRequestException('At least one event is required');
+    }
+
     if (events.length > this.MAX_EVENTS_PER_WEBHOOK) {
       throw new UnprocessableEntityException(
         `Maximum ${this.MAX_EVENTS_PER_WEBHOOK} events allowed per webhook`,
@@ -58,7 +69,7 @@ export class WebhookService implements OnModuleDestroy {
 
     const webhook = this.webhookRepo.create({
       url,
-      secret,
+      secret: secret || crypto.randomBytes(24).toString('hex'),
       events,
       user: { id: userId },
       isActive: true,
@@ -68,6 +79,30 @@ export class WebhookService implements OnModuleDestroy {
 
   async getUserWebhooks(userId: string): Promise<Webhook[]> {
     return this.webhookRepo.find({ where: { user: { id: userId } } });
+  }
+
+  async updateWebhook(
+    userId: string,
+    webhookId: string,
+    updates: Partial<Pick<Webhook, 'url' | 'events' | 'isActive'>>,
+  ): Promise<Webhook> {
+    const webhook = await this.webhookRepo.findOne({
+      where: { id: webhookId },
+      relations: ['user'],
+    });
+
+    if (!webhook) throw new NotFoundException('Webhook not found');
+    if (webhook.user.id !== userId) throw new ForbiddenException('Not your webhook');
+
+    if (updates.url) this.validateWebhookUrl(updates.url);
+    if (updates.events && updates.events.length > this.MAX_EVENTS_PER_WEBHOOK) {
+      throw new UnprocessableEntityException(
+        `Maximum ${this.MAX_EVENTS_PER_WEBHOOK} events allowed per webhook`,
+      );
+    }
+
+    Object.assign(webhook, updates);
+    return this.webhookRepo.save(webhook);
   }
 
   async deleteWebhook(userId: string, webhookId: string): Promise<void> {
@@ -90,29 +125,99 @@ export class WebhookService implements OnModuleDestroy {
     };
     for (const webhook of webhooks) {
       if (webhook.events.includes(event)) {
-        // Await the promise or handle it properly
         void this.deliverWebhook(webhook, payload);
       }
     }
+  }
+
+  async getWebhookDeliveries(userId: string, webhookId: string): Promise<WebhookDelivery[]> {
+    const webhook = await this.webhookRepo.findOne({
+      where: { id: webhookId },
+      relations: ['user'],
+    });
+
+    if (!webhook) throw new NotFoundException('Webhook not found');
+    if (webhook.user.id !== userId) throw new ForbiddenException('Not your webhook');
+
+    return this.deliveryRepo.find({
+      where: { webhook: { id: webhookId } },
+      order: { createdAt: 'DESC' },
+    });
+  }
+
+  async retryWebhookDelivery(userId: string, webhookId: string): Promise<WebhookDelivery> {
+    const webhook = await this.webhookRepo.findOne({
+      where: { id: webhookId },
+      relations: ['user'],
+    });
+
+    if (!webhook) throw new NotFoundException('Webhook not found');
+    if (webhook.user.id !== userId) throw new ForbiddenException('Not your webhook');
+
+    const payload: WebhookPayload = {
+      event: 'webhook.retry',
+      data: { webhookId },
+      timestamp: new Date().toISOString(),
+    };
+
+    return this.deliverWebhook(webhook, payload, 1, true);
+  }
+
+  async testWebhook(userId: string, webhookId: string): Promise<WebhookDelivery> {
+    const webhook = await this.webhookRepo.findOne({
+      where: { id: webhookId },
+      relations: ['user'],
+    });
+
+    if (!webhook) throw new NotFoundException('Webhook not found');
+    if (webhook.user.id !== userId) throw new ForbiddenException('Not your webhook');
+
+    const payload: WebhookPayload = {
+      event: 'webhook.test',
+      data: { status: 'ping' },
+      timestamp: new Date().toISOString(),
+    };
+
+    return this.deliverWebhook(webhook, payload, 1, true);
   }
 
   async deliverWebhook(
     webhook: Webhook,
     payload: WebhookPayload,
     attempt = 1,
-  ): Promise<void> {
-    const maxAttempts = 5;
-    const backoff = Math.pow(2, attempt) * 1000;
+    shouldPersist = false,
+  ): Promise<WebhookDelivery> {
     const signature = this.signPayload(webhook.secret, payload);
+    const delivery = this.deliveryRepo.create({
+      webhook,
+      event: payload.event,
+      payload,
+      attemptCount: attempt,
+      nextRetryAt:
+        attempt < this.MAX_FAILURES
+          ? new Date(Date.now() + this.RETRY_DELAYS_MS[attempt - 1])
+          : null,
+    });
+    const savedDelivery = await this.deliveryRepo.save(delivery);
+
     try {
-      await axios.post(webhook.url, payload, {
+      const response = await axios.post(webhook.url, payload, {
         headers: {
           'X-Vaultix-Signature': signature,
           'Content-Type': 'application/json',
         },
         timeout: 5000,
       });
+
+      savedDelivery.responseStatus = response.status;
+      savedDelivery.nextRetryAt = null;
+      await this.deliveryRepo.save(savedDelivery);
+
+      webhook.lastTriggeredAt = new Date();
+      webhook.failureCount = 0;
+      await this.webhookRepo.save(webhook);
       this.logger.log(`Webhook delivered to ${webhook.url}`);
+      return savedDelivery;
     } catch (err: unknown) {
       let errorMsg = 'Unknown error';
       if (typeof err === 'object' && err !== null && 'message' in err) {
@@ -121,18 +226,39 @@ export class WebhookService implements OnModuleDestroy {
       this.logger.warn(
         `Webhook delivery failed (attempt ${attempt}) to ${webhook.url}: ${errorMsg}`,
       );
-      if (attempt < maxAttempts) {
+
+      savedDelivery.responseStatus = 0;
+      await this.deliveryRepo.save(savedDelivery);
+
+      webhook.failureCount += 1;
+      const shouldDisable = webhook.failureCount >= this.MAX_FAILURES;
+      if (shouldDisable) {
+        webhook.isActive = false;
+      }
+      await this.webhookRepo.save(webhook);
+
+      if (attempt < this.MAX_FAILURES) {
         const timeoutId = `${webhook.id}-${attempt}`;
         const timeout = setTimeout(() => {
           this.timeouts.delete(timeoutId);
-          void this.deliverWebhook(webhook, payload, attempt + 1);
-        }, backoff);
+          void this.deliverWebhook(webhook, payload, attempt + 1, shouldPersist);
+        }, this.RETRY_DELAYS_MS[attempt - 1]);
         this.timeouts.set(timeoutId, timeout);
-      } else {
-        this.logger.error(
-          `Webhook delivery permanently failed to ${webhook.url}`,
-        );
       }
+
+      return savedDelivery;
+    }
+  }
+
+  private validateWebhookUrl(url: string): void {
+    try {
+      const parsed = new URL(url);
+      const requireHttps = process.env.NODE_ENV === 'production';
+      if (requireHttps && parsed.protocol !== 'https:') {
+        throw new BadRequestException('Webhook URL must use HTTPS');
+      }
+    } catch {
+      throw new BadRequestException('Invalid webhook URL');
     }
   }
 


### PR DESCRIPTION

## Summary
This PR adds a complete backend webhook system for user-managed webhooks, including registration, updates, deletion, delivery tracking, retry scheduling, and test ping support.

## What changed
- Added webhook registration and management endpoints
- Implemented HMAC-SHA256 signing with the X-Vaultix-Signature header
- Added webhook delivery persistence and delivery history retrieval
- Implemented retry logic with exponential backoff and retry windows
- Disabled webhooks after repeated failures
- Added HTTPS URL validation for production and test ping support
- Added unit tests for webhook service behavior

## Notes
- The webhook service now auto-generates a signing secret when one is not provided.
- Webhooks are limited to 10 per user, with a maximum of 8 subscribed events per webhook.

## Verification
- TypeScript diagnostics for the changed webhook files report no errors.

closes #417 