### PR TITLE
feat(webhook): add retry mechanism with exponential backoff and deliv…

### DIFF
--- a/apps/backend/src/app.module.ts
+++ b/apps/backend/src/app.module.ts
@@ -25,6 +25,7 @@ import { NotificationPreference } from './notifications/entities/notification-pr
 import { ApiKey } from './api-key/entities/api-key.entity';
 import { AdminAuditLog } from './modules/admin/entities/admin-audit-log.entity';
 import { Webhook } from './modules/webhook/webhook.entity';
+import { WebhookDelivery } from './modules/webhook/entities/webhook-delivery.entity';
 import { StellarEvent } from './modules/stellar/entities/stellar-event.entity';
 import { AdminModule } from './modules/admin/admin.module';
 import { StellarEventModule } from './modules/stellar/stellar-event.module';
@@ -66,6 +67,7 @@ import ipfsConfig from './config/ipfs.config';
           ApiKey,
           AdminAuditLog,
           Webhook,
+          WebhookDelivery,
           StellarEvent,
           AllowedAsset,
         ],

--- a/apps/backend/src/data-source.ts
+++ b/apps/backend/src/data-source.ts
@@ -12,6 +12,7 @@ import { NotificationPreference } from './notifications/entities/notification-pr
 import { ApiKey } from './api-key/entities/api-key.entity';
 import { AdminAuditLog } from './modules/admin/entities/admin-audit-log.entity';
 import { Webhook } from './modules/webhook/webhook.entity';
+import { WebhookDelivery } from './modules/webhook/entities/webhook-delivery.entity';
 import { StellarEvent } from './modules/stellar/entities/stellar-event.entity';
 import { AllowedAsset } from './modules/assets/entities/allowed-asset.entity';
 
@@ -33,6 +34,7 @@ export default new DataSource({
     ApiKey,
     AdminAuditLog,
     Webhook,
+    WebhookDelivery,
     StellarEvent,
     AllowedAsset,
   ],

--- a/apps/backend/src/migrations/1780400000000-AddWebhookDeliveryTable.ts
+++ b/apps/backend/src/migrations/1780400000000-AddWebhookDeliveryTable.ts
@@ -1,0 +1,38 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddWebhookDeliveryTable1780400000000
+  implements MigrationInterface
+{
+  name = 'AddWebhookDeliveryTable1780400000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`
+      CREATE TABLE "webhook_delivery" (
+        "id" uuid PRIMARY KEY DEFAULT uuid_generate_v4(),
+        "webhookId" uuid NOT NULL,
+        "event" varchar NOT NULL,
+        "payload" text NOT NULL,
+        "status" varchar NOT NULL DEFAULT 'pending',
+        "attempt" integer NOT NULL DEFAULT 1,
+        "maxAttempts" integer NOT NULL DEFAULT 5,
+        "nextRetryAt" datetime,
+        "lastStatusCode" integer,
+        "lastError" text,
+        "lastAttemptAt" datetime,
+        "createdAt" datetime DEFAULT now(),
+        "updatedAt" datetime DEFAULT now(),
+        CONSTRAINT "FK_webhook_delivery_webhook" FOREIGN KEY ("webhookId") REFERENCES "webhooks"("id") ON DELETE CASCADE
+      )
+    `);
+    await queryRunner.query(
+      `CREATE INDEX "idx_webhook_delivery_status_retry" ON "webhook_delivery" ("status", "nextRetryAt")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `DROP INDEX IF EXISTS "idx_webhook_delivery_status_retry"`,
+    );
+    await queryRunner.query(`DROP TABLE "webhook_delivery"`);
+  }
+}

--- a/apps/backend/src/modules/admin/admin.module.ts
+++ b/apps/backend/src/modules/admin/admin.module.ts
@@ -1,4 +1,4 @@
-import { Module } from '@nestjs/common';
+import { Module, forwardRef } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 
 import { AdminController } from './admin.controller';
@@ -16,6 +16,8 @@ import { AdminAuditLogService } from './services/admin-audit-log.service';
 import { AnalyticsService } from './services/analytics.service';
 import { AnalyticsController } from './controllers/analytics.controller';
 import { Dispute } from '../escrow/entities/dispute.entity';
+import { WebhookModule } from '../webhook/webhook.module';
+import { AdminWebhookController } from './controllers/admin-webhook.controller';
 
 @Module({
   imports: [
@@ -29,11 +31,13 @@ import { Dispute } from '../escrow/entities/dispute.entity';
       Dispute,
     ]),
     EscrowModule,
+    forwardRef(() => WebhookModule),
   ],
   controllers: [
     AdminController,
     AdminEscrowConsistencyController,
     AnalyticsController,
+    AdminWebhookController,
   ],
   providers: [
     AdminService,

--- a/apps/backend/src/modules/admin/controllers/admin-webhook.controller.ts
+++ b/apps/backend/src/modules/admin/controllers/admin-webhook.controller.ts
@@ -1,0 +1,46 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Param,
+  Query,
+  UseGuards,
+  HttpStatus,
+  HttpCode,
+} from '@nestjs/common';
+import { AuthGuard } from '../../auth/middleware/auth.guard';
+import { AdminGuard } from '../../auth/middleware/admin.guard';
+import { WebhookService } from '../../../services/webhook/webhook.service';
+
+@Controller('admin/webhooks')
+@UseGuards(AuthGuard, AdminGuard)
+export class AdminWebhookController {
+  constructor(private readonly webhookService: WebhookService) {}
+
+  @Get('failed')
+  async getFailedDeliveries(
+    @Query('page') page = '1',
+    @Query('limit') limit = '20',
+    @Query('webhookId') webhookId?: string,
+  ) {
+    const parsedPage = Number.parseInt(page, 10);
+    const parsedLimit = Number.parseInt(limit, 10);
+
+    return this.webhookService.getFailedDelveys({
+      page: Number.isNaN(parsedPage) ? 1 : parsedPage,
+      limit: Number.isNaN(parsedLimit) ? 20 : parsedLimit,
+      webhookId,
+    });
+  }
+
+  @Post(':deliveryId/retry')
+  @HttpCode(HttpStatus.OK)
+  async manualRetry(@Param('deliveryId') deliveryId: string) {
+    return this.webhookService.manualRetry(deliveryId);
+  }
+
+  @Get('health')
+  async getHealthStats() {
+    return this.webhookService.getHealthStats();
+  }
+}

--- a/apps/backend/src/modules/webhook/entities/webhook-delivery.entity.ts
+++ b/apps/backend/src/modules/webhook/entities/webhook-delivery.entity.ts
@@ -1,0 +1,61 @@
+import {
+  Column,
+  Entity,
+  PrimaryGeneratedColumn,
+  ManyToOne,
+  CreateDateColumn,
+  UpdateDateColumn,
+  Index,
+} from 'typeorm';
+import { Webhook } from '../webhook.entity';
+import { WebhookDeliveryStatus } from '../../../types/webhook/webhook.types';
+
+@Entity('webhook_delivery')
+@Index(['status', 'nextRetryAt'])
+export class WebhookDelivery {
+  @PrimaryGeneratedColumn('uuid')
+  id!: string;
+
+  @ManyToOne(() => Webhook, { onDelete: 'CASCADE' })
+  webhook!: Webhook;
+
+  @Column()
+  webhookId!: string;
+
+  @Column()
+  event!: string;
+
+  @Column({ type: 'simple-json' })
+  payload!: Record<string, unknown>;
+
+  @Column({
+    type: 'simple-enum',
+    enum: WebhookDeliveryStatus,
+    default: WebhookDeliveryStatus.PENDING,
+  })
+  status!: WebhookDeliveryStatus;
+
+  @Column({ default: 1 })
+  attempt!: number;
+
+  @Column({ default: 5 })
+  maxAttempts!: number;
+
+  @Column({ type: 'datetime', nullable: true })
+  nextRetryAt!: Date | null;
+
+  @Column({ nullable: true })
+  lastStatusCode!: number | null;
+
+  @Column({ type: 'text', nullable: true })
+  lastError!: string | null;
+
+  @Column({ type: 'datetime', nullable: true })
+  lastAttemptAt!: Date | null;
+
+  @CreateDateColumn()
+  createdAt!: Date;
+
+  @UpdateDateColumn()
+  updatedAt!: Date;
+}

--- a/apps/backend/src/modules/webhook/webhook.entity.ts
+++ b/apps/backend/src/modules/webhook/webhook.entity.ts
@@ -12,26 +12,26 @@ import type { WebhookEvent } from '../../types/webhook/webhook.types';
 @Entity('webhooks')
 export class Webhook {
   @PrimaryGeneratedColumn('uuid')
-  id: string;
+  id!: string;
 
   @Column()
-  url: string;
+  url!: string;
 
   @Column()
-  secret: string;
+  secret!: string;
 
   @Column('simple-array')
-  events: WebhookEvent[];
+  events!: WebhookEvent[];
 
   @Column({ default: true })
-  isActive: boolean;
+  isActive!: boolean;
 
   @ManyToOne(() => User, { nullable: false })
-  user: User;
+  user!: User;
 
   @CreateDateColumn()
-  createdAt: Date;
+  createdAt!: Date;
 
   @UpdateDateColumn()
-  updatedAt: Date;
+  updatedAt!: Date;
 }

--- a/apps/backend/src/modules/webhook/webhook.module.ts
+++ b/apps/backend/src/modules/webhook/webhook.module.ts
@@ -2,11 +2,12 @@ import { Module } from '@nestjs/common';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { AuthModule } from '../auth/auth.module';
 import { Webhook } from './webhook.entity';
+import { WebhookDelivery } from './entities/webhook-delivery.entity';
 import { WebhookService } from '../../services/webhook/webhook.service';
 import { WebhookController } from './webhook.controller';
 
 @Module({
-  imports: [TypeOrmModule.forFeature([Webhook]), AuthModule],
+  imports: [TypeOrmModule.forFeature([Webhook, WebhookDelivery]), AuthModule],
   providers: [WebhookService],
   controllers: [WebhookController],
   exports: [WebhookService],

--- a/apps/backend/src/services/webhook/webhook.service.spec.ts
+++ b/apps/backend/src/services/webhook/webhook.service.spec.ts
@@ -2,9 +2,10 @@ import { Test, TestingModule } from '@nestjs/testing';
 import { WebhookService } from './webhook.service';
 import { getRepositoryToken } from '@nestjs/typeorm';
 import { Webhook } from '../../modules/webhook/webhook.entity';
+import { WebhookDelivery } from '../../modules/webhook/entities/webhook-delivery.entity';
 import { Repository } from 'typeorm';
 import axios from 'axios';
-import { WebhookEvent } from '../../types/webhook/webhook.types';
+import { WebhookDeliveryStatus } from '../../types/webhook/webhook.types';
 import {
   NotFoundException,
   ForbiddenException,
@@ -16,7 +17,8 @@ const mockedAxios = axios as jest.Mocked<typeof axios>;
 
 describe('WebhookService', () => {
   let service: WebhookService;
-  let repo: jest.Mocked<Repository<Webhook>>;
+  let webhookRepo: jest.Mocked<Repository<Webhook>>;
+  let deliveryRepo: jest.Mocked<Repository<WebhookDelivery>>;
 
   beforeEach(async () => {
     const module: TestingModule = await Test.createTestingModule({
@@ -32,11 +34,24 @@ describe('WebhookService', () => {
             delete: jest.fn(),
           },
         },
+        {
+          provide: getRepositoryToken(WebhookDelivery),
+          useValue: {
+            find: jest.fn(),
+            findOne: jest.fn(),
+            create: jest.fn(),
+            save: jest.fn(),
+            delete: jest.fn(),
+            findAndCount: jest.fn(),
+            count: jest.fn(),
+          },
+        },
       ],
     }).compile();
 
     service = module.get<WebhookService>(WebhookService);
-    repo = module.get(getRepositoryToken(Webhook));
+    webhookRepo = module.get(getRepositoryToken(Webhook));
+    deliveryRepo = module.get(getRepositoryToken(WebhookDelivery));
   });
 
   const mockWebhook = {
@@ -50,15 +65,15 @@ describe('WebhookService', () => {
 
   describe('createWebhook', () => {
     it('should create a webhook if within limits', async () => {
-      repo.find.mockResolvedValue([]);
-      repo.create.mockReturnValue(mockWebhook as any);
-      repo.save.mockResolvedValue(mockWebhook as any);
+      webhookRepo.find.mockResolvedValue([]);
+      webhookRepo.create.mockReturnValue(mockWebhook as any);
+      webhookRepo.save.mockResolvedValue(mockWebhook as any);
 
       const result = await service.createWebhook('u1', 'test.com', 'secret', [
         'escrow.created',
       ]);
 
-      expect(repo.save).toHaveBeenCalled();
+      expect(webhookRepo.save).toHaveBeenCalled();
       expect(result).toEqual(mockWebhook);
     });
 
@@ -74,7 +89,7 @@ describe('WebhookService', () => {
     });
 
     it('should throw if user exceeds webhook limit', async () => {
-      repo.find.mockResolvedValue(Array(11).fill(mockWebhook) as any);
+      webhookRepo.find.mockResolvedValue(Array(11).fill(mockWebhook) as any);
       await expect(
         service.createWebhook('u1', 'test.com', 'secret', ['escrow.created']),
       ).rejects.toThrow(UnprocessableEntityException);
@@ -83,20 +98,23 @@ describe('WebhookService', () => {
 
   describe('deleteWebhook', () => {
     it('should delete if owned by user', async () => {
-      repo.findOne.mockResolvedValue(mockWebhook as any);
+      webhookRepo.findOne.mockResolvedValue(mockWebhook as any);
       await service.deleteWebhook('u1', 'w1');
-      expect(repo.delete).toHaveBeenCalledWith('w1');
+      expect(webhookRepo.delete).toHaveBeenCalledWith('w1');
     });
 
     it('should throw if not owned by user', async () => {
-      repo.findOne.mockResolvedValue({ id: 'w1', user: { id: 'u2' } } as any);
+      webhookRepo.findOne.mockResolvedValue({
+        id: 'w1',
+        user: { id: 'u2' },
+      } as any);
       await expect(service.deleteWebhook('u1', 'w1')).rejects.toThrow(
         ForbiddenException,
       );
     });
 
     it('should throw if webhook not found', async () => {
-      repo.findOne.mockResolvedValue(null);
+      webhookRepo.findOne.mockResolvedValue(null);
       await expect(service.deleteWebhook('u1', 'w1')).rejects.toThrow(
         NotFoundException,
       );
@@ -104,51 +122,326 @@ describe('WebhookService', () => {
   });
 
   describe('dispatchEvent', () => {
-    it('should call deliverWebhook for each active webhook with matching event', async () => {
-      repo.find.mockResolvedValue([mockWebhook] as any);
-      const deliverSpy = jest
-        .spyOn(service, 'deliverWebhook')
-        .mockReturnValue(Promise.resolve());
+    it('should create a delivery record and attempt delivery for matching webhooks', async () => {
+      webhookRepo.find.mockResolvedValue([mockWebhook] as any);
+      const mockDelivery = {
+        id: 'd1',
+        webhookId: 'w1',
+        webhook: mockWebhook,
+        event: 'escrow.created',
+        payload: {
+          event: 'escrow.created',
+          data: { foo: 'bar' },
+          timestamp: expect.any(String),
+        },
+        status: WebhookDeliveryStatus.PENDING,
+        attempt: 1,
+        maxAttempts: 5,
+        nextRetryAt: expect.any(Date),
+        lastStatusCode: null,
+        lastError: null,
+        lastAttemptAt: null,
+      };
+      deliveryRepo.create.mockReturnValue(mockDelivery as any);
+      deliveryRepo.save.mockResolvedValue(mockDelivery as any);
+
+      const attemptSpy = jest
+        .spyOn(service, 'attemptDelivery')
+        .mockImplementation(() => Promise.resolve());
 
       await service.dispatchEvent('escrow.created', { foo: 'bar' });
 
-      expect(deliverSpy).toHaveBeenCalledWith(
-        mockWebhook,
-        expect.objectContaining({ event: 'escrow.created' }),
+      expect(deliveryRepo.create).toHaveBeenCalledWith(
+        expect.objectContaining({
+          webhookId: 'w1',
+          event: 'escrow.created',
+          status: WebhookDeliveryStatus.PENDING,
+          attempt: 1,
+          maxAttempts: 5,
+        }),
+      );
+      expect(deliveryRepo.save).toHaveBeenCalled();
+      expect(attemptSpy).toHaveBeenCalledWith(mockDelivery);
+    });
+
+    it('should not create delivery for webhooks that do not match the event', async () => {
+      const nonMatchingWebhook = { ...mockWebhook, events: ['escrow.funded'] };
+      webhookRepo.find.mockResolvedValue([nonMatchingWebhook] as any);
+
+      await service.dispatchEvent('escrow.created', { foo: 'bar' });
+
+      expect(deliveryRepo.create).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('attemptDelivery', () => {
+    const baseDelivery = {
+      id: 'd1',
+      webhookId: 'w1',
+      webhook: mockWebhook,
+      event: 'escrow.created',
+      payload: { event: 'escrow.created', data: {}, timestamp: 'now' },
+      status: WebhookDeliveryStatus.PENDING,
+      attempt: 1,
+      maxAttempts: 5,
+      nextRetryAt: new Date(),
+      lastStatusCode: null,
+      lastError: null,
+      lastAttemptAt: null,
+    };
+
+    it('should mark as delivered on success', async () => {
+      mockedAxios.post.mockResolvedValue({ status: 200 });
+      const delivery = { ...baseDelivery };
+      deliveryRepo.save.mockImplementation((d) => Promise.resolve(d as any));
+
+      await service.attemptDelivery(delivery as any);
+
+      expect(delivery.status).toBe(WebhookDeliveryStatus.DELIVERED);
+      expect(delivery.lastStatusCode).toBe(200);
+      expect(delivery.lastError).toBeNull();
+      expect(delivery.nextRetryAt).toBeNull();
+      expect(delivery.lastAttemptAt).toBeInstanceOf(Date);
+    });
+
+    it('should set status to retrying on failure with attempts remaining', async () => {
+      mockedAxios.post.mockRejectedValue(new Error('Network error'));
+      const delivery = { ...baseDelivery, attempt: 1 };
+      deliveryRepo.save.mockImplementation((d) => Promise.resolve(d as any));
+
+      await service.attemptDelivery(delivery as any);
+
+      expect(delivery.status).toBe(WebhookDeliveryStatus.RETRYING);
+      expect(delivery.attempt).toBe(2);
+      expect(delivery.lastError).toBe('Network error');
+      expect(delivery.nextRetryAt).toBeInstanceOf(Date);
+    });
+
+    it('should calculate exponential backoff: 1s for attempt 1', async () => {
+      mockedAxios.post.mockRejectedValue(new Error('fail'));
+      const delivery = { ...baseDelivery, attempt: 1 };
+      deliveryRepo.save.mockImplementation((d) => Promise.resolve(d as any));
+      const before = Date.now();
+
+      await service.attemptDelivery(delivery as any);
+
+      const backoffMs = delivery.nextRetryAt.getTime() - before;
+      expect(backoffMs).toBeGreaterThanOrEqual(900);
+      expect(backoffMs).toBeLessThanOrEqual(1200);
+    });
+
+    it('should calculate exponential backoff: 2s for attempt 2', async () => {
+      mockedAxios.post.mockRejectedValue(new Error('fail'));
+      const delivery = { ...baseDelivery, attempt: 2 };
+      deliveryRepo.save.mockImplementation((d) => Promise.resolve(d as any));
+      const before = Date.now();
+
+      await service.attemptDelivery(delivery as any);
+
+      const backoffMs = delivery.nextRetryAt.getTime() - before;
+      expect(backoffMs).toBeGreaterThanOrEqual(1900);
+      expect(backoffMs).toBeLessThanOrEqual(2200);
+    });
+
+    it('should calculate exponential backoff: 4s for attempt 3', async () => {
+      mockedAxios.post.mockRejectedValue(new Error('fail'));
+      const delivery = { ...baseDelivery, attempt: 3 };
+      deliveryRepo.save.mockImplementation((d) => Promise.resolve(d as any));
+      const before = Date.now();
+
+      await service.attemptDelivery(delivery as any);
+
+      const backoffMs = delivery.nextRetryAt.getTime() - before;
+      expect(backoffMs).toBeGreaterThanOrEqual(3900);
+      expect(backoffMs).toBeLessThanOrEqual(4200);
+    });
+
+    it('should mark as failed when max attempts exhausted', async () => {
+      mockedAxios.post.mockRejectedValue(new Error('Network error'));
+      const delivery = { ...baseDelivery, attempt: 5 };
+      deliveryRepo.save.mockImplementation((d) => Promise.resolve(d as any));
+
+      await service.attemptDelivery(delivery as any);
+
+      expect(delivery.status).toBe(WebhookDeliveryStatus.FAILED);
+      expect(delivery.nextRetryAt).toBeNull();
+      expect(delivery.lastError).toBe('Network error');
+    });
+
+    it('should capture HTTP status code from error response', async () => {
+      const axiosError = {
+        response: { status: 500 },
+        message: 'Request failed with status code 500',
+      };
+      mockedAxios.post.mockRejectedValue(axiosError);
+      const delivery = { ...baseDelivery, attempt: 1 };
+      deliveryRepo.save.mockImplementation((d) => Promise.resolve(d as any));
+
+      await service.attemptDelivery(delivery as any);
+
+      expect(delivery.lastStatusCode).toBe(500);
+    });
+
+    it('should mark as failed if webhook entity no longer exists', async () => {
+      const delivery = { ...baseDelivery, webhook: undefined, webhookId: 'w1' };
+      webhookRepo.findOne.mockResolvedValue(null);
+      deliveryRepo.save.mockImplementation((d) => Promise.resolve(d as any));
+
+      await service.attemptDelivery(delivery as any);
+
+      expect(delivery.status).toBe(WebhookDeliveryStatus.FAILED);
+      expect(delivery.lastError).toBe('Webhook not found');
+    });
+  });
+
+  describe('processRetries', () => {
+    it('should pick up retrying deliveries with past nextRetryAt', async () => {
+      const dueDeliveries = [
+        { id: 'd1', status: WebhookDeliveryStatus.RETRYING },
+      ];
+      deliveryRepo.find.mockResolvedValue(dueDeliveries as any);
+
+      const attemptSpy = jest
+        .spyOn(service, 'attemptDelivery')
+        .mockImplementation(() => Promise.resolve());
+
+      await service.processRetries();
+
+      expect(deliveryRepo.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            status: WebhookDeliveryStatus.RETRYING,
+            nextRetryAt: expect.anything(),
+          },
+        }),
+      );
+      expect(attemptSpy).toHaveBeenCalledWith(dueDeliveries[0]);
+    });
+  });
+
+  describe('processPending', () => {
+    it('should pick up pending deliveries with past nextRetryAt', async () => {
+      const pendingDeliveries = [
+        { id: 'd2', status: WebhookDeliveryStatus.PENDING },
+      ];
+      deliveryRepo.find.mockResolvedValue(pendingDeliveries as any);
+
+      const attemptSpy = jest
+        .spyOn(service, 'attemptDelivery')
+        .mockImplementation(() => Promise.resolve());
+
+      await service.processPending();
+
+      expect(deliveryRepo.find).toHaveBeenCalledWith(
+        expect.objectContaining({
+          where: {
+            status: WebhookDeliveryStatus.PENDING,
+            nextRetryAt: expect.anything(),
+          },
+        }),
+      );
+      expect(attemptSpy).toHaveBeenCalledWith(pendingDeliveries[0]);
+    });
+  });
+
+  describe('getFailedDeliveries', () => {
+    it('should return paginated failed deliveries', async () => {
+      const failedDeliveries = [
+        { id: 'd1', status: WebhookDeliveryStatus.FAILED },
+      ];
+      deliveryRepo.findAndCount.mockResolvedValue([failedDeliveries as any, 1]);
+
+      const result = await service.getFailedDelveys({ page: 1, limit: 20 });
+
+      expect(result.deliveries).toEqual(failedDeliveries);
+      expect(result.pagination).toEqual({
+        page: 1,
+        limit: 20,
+        total: 1,
+        pages: 1,
+      });
+    });
+  });
+
+  describe('manualRetry', () => {
+    it('should reset a failed delivery and re-attempt', async () => {
+      const failedDelivery = {
+        id: 'd1',
+        status: WebhookDeliveryStatus.FAILED,
+        attempt: 5,
+        nextRetryAt: null,
+        lastStatusCode: 500,
+        lastError: 'Internal Server Error',
+        lastAttemptAt: new Date(),
+        webhook: mockWebhook,
+      };
+      deliveryRepo.findOne.mockResolvedValue(failedDelivery as any);
+      deliveryRepo.save.mockImplementation((d) => Promise.resolve(d as any));
+      const attemptSpy = jest
+        .spyOn(service, 'attemptDelivery')
+        .mockImplementation(() => Promise.resolve());
+
+      const result = await service.manualRetry('d1');
+
+      expect(result.status).toBe(WebhookDeliveryStatus.PENDING);
+      expect(result.attempt).toBe(1);
+      expect(result.lastStatusCode).toBeNull();
+      expect(result.lastError).toBeNull();
+      expect(attemptSpy).toHaveBeenCalled();
+    });
+
+    it('should throw if delivery not found', async () => {
+      deliveryRepo.findOne.mockResolvedValue(null);
+      await expect(service.manualRetry('nonexistent')).rejects.toThrow(
+        NotFoundException,
+      );
+    });
+
+    it('should throw if delivery is not in failed status', async () => {
+      deliveryRepo.findOne.mockResolvedValue({
+        id: 'd1',
+        status: WebhookDeliveryStatus.DELIVERED,
+      } as any);
+      await expect(service.manualRetry('d1')).rejects.toThrow(
+        ForbiddenException,
       );
     });
   });
 
-  describe('deliverWebhook', () => {
-    it('should post payload and log success', async () => {
-      mockedAxios.post.mockResolvedValue({ status: 200 });
+  describe('getHealthStats', () => {
+    it('should return correct health stats', async () => {
+      deliveryRepo.count
+        .mockResolvedValueOnce(100)
+        .mockResolvedValueOnce(80)
+        .mockResolvedValueOnce(10)
+        .mockResolvedValueOnce(5)
+        .mockResolvedValueOnce(5);
 
-      await service.deliverWebhook(mockWebhook as any, {
-        event: 'escrow.created',
-        data: {},
-        timestamp: 'now',
+      const result = await service.getHealthStats();
+
+      expect(result).toEqual({
+        total: 100,
+        delivered: 80,
+        failed: 10,
+        retrying: 5,
+        pending: 5,
+        successRate: 88.89,
+        failureRate: 11.11,
       });
-
-      expect(mockedAxios.post).toHaveBeenCalled();
     });
 
-    it('should retry on failure', async () => {
-      const loggerWarn = jest
-        .spyOn((service as any).logger, 'warn')
-        .mockImplementation(() => {});
-      mockedAxios.post.mockRejectedValue(new Error('Network error'));
-      jest.useFakeTimers();
+    it('should return zero rates when no completed deliveries exist', async () => {
+      deliveryRepo.count
+        .mockResolvedValueOnce(5)
+        .mockResolvedValueOnce(0)
+        .mockResolvedValueOnce(0)
+        .mockResolvedValueOnce(2)
+        .mockResolvedValueOnce(3);
 
-      const deliverSpy = jest.spyOn(service, 'deliverWebhook');
-      await service.deliverWebhook(mockWebhook as any, {} as any, 1);
+      const result = await service.getHealthStats();
 
-      expect(loggerWarn).toHaveBeenCalled();
-      jest.runAllTimers();
-      expect(deliverSpy).toHaveBeenCalledWith(
-        mockWebhook,
-        expect.anything(),
-        2,
-      );
+      expect(result.successRate).toBe(0);
+      expect(result.failureRate).toBe(0);
     });
   });
 

--- a/apps/backend/src/services/webhook/webhook.service.ts
+++ b/apps/backend/src/services/webhook/webhook.service.ts
@@ -3,37 +3,35 @@ import {
   NotFoundException,
   ForbiddenException,
   Logger,
-  OnModuleDestroy,
   UnprocessableEntityException,
 } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
-import { Repository } from 'typeorm';
+import { Repository, LessThan } from 'typeorm';
+import { Cron, CronExpression } from '@nestjs/schedule';
 import { Webhook } from '../../modules/webhook/webhook.entity';
+import { WebhookDelivery } from '../../modules/webhook/entities/webhook-delivery.entity';
 import {
   WebhookEvent,
   WebhookPayload,
+  WebhookDeliveryStatus,
 } from '../../types/webhook/webhook.types';
 import * as crypto from 'crypto';
 import axios from 'axios';
 
 @Injectable()
-export class WebhookService implements OnModuleDestroy {
+export class WebhookService {
   private readonly logger = new Logger(WebhookService.name);
-  private timeouts: Map<string, NodeJS.Timeout> = new Map();
   private readonly MAX_WEBHOOKS_PER_USER = 10;
   private readonly MAX_EVENTS_PER_WEBHOOK = 8;
+  private readonly MAX_RETRY_ATTEMPTS = 5;
+  private readonly BASE_RETRY_DELAY_MS = 1000;
 
   constructor(
     @InjectRepository(Webhook)
     private readonly webhookRepo: Repository<Webhook>,
+    @InjectRepository(WebhookDelivery)
+    private readonly deliveryRepo: Repository<WebhookDelivery>,
   ) {}
-
-  onModuleDestroy() {
-    for (const timeout of this.timeouts.values()) {
-      clearTimeout(timeout);
-    }
-    this.timeouts.clear();
-  }
 
   async createWebhook(
     userId: string,
@@ -41,14 +39,12 @@ export class WebhookService implements OnModuleDestroy {
     secret: string,
     events: WebhookEvent[],
   ): Promise<Webhook> {
-    // Check maximum events per webhook
     if (events.length > this.MAX_EVENTS_PER_WEBHOOK) {
       throw new UnprocessableEntityException(
         `Maximum ${this.MAX_EVENTS_PER_WEBHOOK} events allowed per webhook`,
       );
     }
 
-    // Check maximum webhooks per user
     const existingWebhooks = await this.getUserWebhooks(userId);
     if (existingWebhooks.length >= this.MAX_WEBHOOKS_PER_USER) {
       throw new UnprocessableEntityException(
@@ -90,50 +86,219 @@ export class WebhookService implements OnModuleDestroy {
     };
     for (const webhook of webhooks) {
       if (webhook.events.includes(event)) {
-        // Await the promise or handle it properly
-        void this.deliverWebhook(webhook, payload);
+        const delivery = this.deliveryRepo.create({
+          webhook,
+          webhookId: webhook.id,
+          event,
+          payload: payload as unknown as Record<string, unknown>,
+          status: WebhookDeliveryStatus.PENDING,
+          attempt: 1,
+          maxAttempts: this.MAX_RETRY_ATTEMPTS,
+          nextRetryAt: new Date(),
+          lastStatusCode: null,
+          lastError: null,
+          lastAttemptAt: null,
+        });
+        const saved = await this.deliveryRepo.save(delivery);
+        void this.attemptDelivery(saved);
       }
     }
   }
 
-  async deliverWebhook(
-    webhook: Webhook,
-    payload: WebhookPayload,
-    attempt = 1,
-  ): Promise<void> {
-    const maxAttempts = 5;
-    const backoff = Math.pow(2, attempt) * 1000;
+  async attemptDelivery(delivery: WebhookDelivery): Promise<void> {
+    const webhook =
+      delivery.webhook ??
+      (await this.webhookRepo.findOne({ where: { id: delivery.webhookId } }));
+    if (!webhook) {
+      delivery.status = WebhookDeliveryStatus.FAILED;
+      delivery.lastError = 'Webhook not found';
+      delivery.lastAttemptAt = new Date();
+      await this.deliveryRepo.save(delivery);
+      return;
+    }
+
+    const payload = delivery.payload as unknown as WebhookPayload;
     const signature = this.signPayload(webhook.secret, payload);
+    let statusCode: number | null = null;
+    let errorMsg: string | null = null;
+
     try {
-      await axios.post(webhook.url, payload, {
+      const response = await axios.post(webhook.url, payload, {
         headers: {
           'X-Vaultix-Signature': signature,
           'Content-Type': 'application/json',
         },
         timeout: 5000,
       });
+      statusCode = response.status;
+      delivery.status = WebhookDeliveryStatus.DELIVERED;
+      delivery.nextRetryAt = null;
       this.logger.log(`Webhook delivered to ${webhook.url}`);
     } catch (err: unknown) {
-      let errorMsg = 'Unknown error';
-      if (typeof err === 'object' && err !== null && 'message' in err) {
-        errorMsg = (err as { message?: string }).message ?? errorMsg;
-      }
-      this.logger.warn(
-        `Webhook delivery failed (attempt ${attempt}) to ${webhook.url}: ${errorMsg}`,
-      );
-      if (attempt < maxAttempts) {
-        const timeoutId = `${webhook.id}-${attempt}`;
-        const timeout = setTimeout(() => {
-          this.timeouts.delete(timeoutId);
-          void this.deliverWebhook(webhook, payload, attempt + 1);
-        }, backoff);
-        this.timeouts.set(timeoutId, timeout);
+      if (typeof err === 'object' && err !== null && 'response' in err) {
+        const axiosErr = err as {
+          response?: { status?: number };
+          message?: string;
+        };
+        statusCode = axiosErr.response?.status ?? null;
+        errorMsg = axiosErr.message ?? 'Unknown error';
+      } else if (typeof err === 'object' && err !== null && 'message' in err) {
+        errorMsg = (err as { message?: string }).message ?? 'Unknown error';
       } else {
+        errorMsg = 'Unknown error';
+      }
+
+      if (delivery.attempt < delivery.maxAttempts) {
+        delivery.status = WebhookDeliveryStatus.RETRYING;
+        const backoffMs =
+          this.BASE_RETRY_DELAY_MS * Math.pow(2, delivery.attempt - 1);
+        const nextRetry = new Date(Date.now() + backoffMs);
+        delivery.nextRetryAt = nextRetry;
+        delivery.attempt += 1;
+        this.logger.warn(
+          `Webhook delivery failed (attempt ${delivery.attempt - 1}) to ${webhook.url}: ${errorMsg}`,
+        );
+      } else {
+        delivery.status = WebhookDeliveryStatus.FAILED;
+        delivery.nextRetryAt = null;
         this.logger.error(
           `Webhook delivery permanently failed to ${webhook.url}`,
         );
       }
     }
+
+    delivery.lastStatusCode = statusCode;
+    delivery.lastError = errorMsg;
+    delivery.lastAttemptAt = new Date();
+    await this.deliveryRepo.save(delivery);
+  }
+
+  @Cron(CronExpression.EVERY_10_SECONDS)
+  async processRetries(): Promise<void> {
+    const due = await this.deliveryRepo.find({
+      where: {
+        status: WebhookDeliveryStatus.RETRYING,
+        nextRetryAt: LessThan(new Date()),
+      },
+      relations: ['webhook'],
+      take: 50,
+    });
+
+    for (const delivery of due) {
+      void this.attemptDelivery(delivery);
+    }
+  }
+
+  @Cron(CronExpression.EVERY_30_SECONDS)
+  async processPending(): Promise<void> {
+    const pending = await this.deliveryRepo.find({
+      where: {
+        status: WebhookDeliveryStatus.PENDING,
+        nextRetryAt: LessThan(new Date()),
+      },
+      relations: ['webhook'],
+      take: 50,
+    });
+
+    for (const delivery of pending) {
+      void this.attemptDelivery(delivery);
+    }
+  }
+
+  async getFailedDelveys(filters?: {
+    page?: number;
+    limit?: number;
+    webhookId?: string;
+  }): Promise<{
+    deliveries: WebhookDelivery[];
+    pagination: { page: number; limit: number; total: number; pages: number };
+  }> {
+    const page = filters?.page ?? 1;
+    const limit = filters?.limit ?? 20;
+
+    const where: Record<string, unknown> = {
+      status: WebhookDeliveryStatus.FAILED,
+    };
+    if (filters?.webhookId) where.webhookId = filters.webhookId;
+
+    const [deliveries, total] = await this.deliveryRepo.findAndCount({
+      where,
+      relations: ['webhook'],
+      skip: (page - 1) * limit,
+      take: limit,
+      order: { updatedAt: 'DESC' },
+    });
+
+    return {
+      deliveries,
+      pagination: {
+        page,
+        limit,
+        total,
+        pages: Math.ceil(total / limit),
+      },
+    };
+  }
+
+  async manualRetry(deliveryId: string): Promise<WebhookDelivery> {
+    const delivery = await this.deliveryRepo.findOne({
+      where: { id: deliveryId },
+      relations: ['webhook'],
+    });
+    if (!delivery) throw new NotFoundException('Delivery not found');
+    if (delivery.status !== WebhookDeliveryStatus.FAILED) {
+      throw new ForbiddenException('Only failed deliveries can be retried');
+    }
+
+    delivery.status = WebhookDeliveryStatus.PENDING;
+    delivery.attempt = 1;
+    delivery.nextRetryAt = new Date();
+    delivery.lastStatusCode = null;
+    delivery.lastError = null;
+    delivery.lastAttemptAt = null;
+    await this.deliveryRepo.save(delivery);
+
+    void this.attemptDelivery(delivery);
+    return delivery;
+  }
+
+  async getHealthStats(): Promise<{
+    total: number;
+    delivered: number;
+    failed: number;
+    retrying: number;
+    pending: number;
+    successRate: number;
+    failureRate: number;
+  }> {
+    const [total, delivered, failed, retrying, pending] = await Promise.all([
+      this.deliveryRepo.count(),
+      this.deliveryRepo.count({
+        where: { status: WebhookDeliveryStatus.DELIVERED },
+      }),
+      this.deliveryRepo.count({
+        where: { status: WebhookDeliveryStatus.FAILED },
+      }),
+      this.deliveryRepo.count({
+        where: { status: WebhookDeliveryStatus.RETRYING },
+      }),
+      this.deliveryRepo.count({
+        where: { status: WebhookDeliveryStatus.PENDING },
+      }),
+    ]);
+
+    const completed = delivered + failed;
+    return {
+      total,
+      delivered,
+      failed,
+      retrying,
+      pending,
+      successRate:
+        completed > 0 ? Math.round((delivered / completed) * 10000) / 100 : 0,
+      failureRate:
+        completed > 0 ? Math.round((failed / completed) * 10000) / 100 : 0,
+    };
   }
 
   signPayload(secret: string, payload: WebhookPayload): string {

--- a/apps/backend/src/types/webhook/webhook.types.ts
+++ b/apps/backend/src/types/webhook/webhook.types.ts
@@ -1,3 +1,10 @@
+export enum WebhookDeliveryStatus {
+  PENDING = 'pending',
+  DELIVERED = 'delivered',
+  RETRYING = 'retrying',
+  FAILED = 'failed',
+}
+
 export type WebhookEvent =
   | 'escrow.created'
   | 'escrow.funded'


### PR DESCRIPTION
…ery tracking

Implement persistent webhook delivery queue with exponential backoff (1s, 2s, 4s, 8s, 16s)

- Add WebhookDelivery entity to track delivery status per event

- Replace in-memory setTimeout retry with cron-based DB-backed retry processor

- Track delivery attempts with response status codes and error messages

- Move permanently failed webhooks (5 retries exhausted) to dead-letter (status=failed)

- Add admin endpoints: GET /admin/webhooks/failed, POST /admin/webhooks/:deliveryId/retry, GET /admin/webhooks/health

- Add WebhookDeliveryStatus enum (pending, delivered, retrying, failed)

Closes #197