### PR TITLE
perf(backend): add escrow query performance indexes

### DIFF
--- a/apps/backend/src/migrations/1780700000000-AddEscrowQueryPerformanceIndexes.spec.ts
+++ b/apps/backend/src/migrations/1780700000000-AddEscrowQueryPerformanceIndexes.spec.ts
@@ -1,0 +1,111 @@
+import { DataSource } from 'typeorm';
+import { AddEscrowQueryPerformanceIndexes } from './1780700000000-AddEscrowQueryPerformanceIndexes';
+
+describe('AddEscrowQueryPerformanceIndexes migration', () => {
+  let dataSource: DataSource;
+
+  beforeEach(async () => {
+    dataSource = new DataSource({
+      type: 'sqlite',
+      database: ':memory:',
+      entities: [],
+      synchronize: false,
+    });
+
+    await dataSource.initialize();
+
+    await dataSource.query(`
+      CREATE TABLE escrows (
+        id TEXT PRIMARY KEY,
+        creatorId TEXT NOT NULL,
+        status TEXT NOT NULL,
+        createdAt DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        expiresAt DATETIME,
+        updatedAt DATETIME
+      )
+    `);
+
+    await dataSource.query(`
+      CREATE TABLE users (
+        id TEXT PRIMARY KEY,
+        walletAddress TEXT NOT NULL
+      )
+    `);
+
+    await dataSource.query(`
+      CREATE TABLE escrow_parties (
+        id TEXT PRIMARY KEY,
+        userId TEXT NOT NULL,
+        escrowId TEXT NOT NULL
+      )
+    `);
+
+    await dataSource.query(`
+      CREATE TABLE escrow_events (
+        id TEXT PRIMARY KEY,
+        escrowId TEXT NOT NULL,
+        createdAt DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+      )
+    `);
+  });
+
+  afterEach(async () => {
+    await dataSource.destroy();
+  });
+
+  it('creates indexes that are used by common escrow queries', async () => {
+    const runner = dataSource.createQueryRunner();
+    const migration = new AddEscrowQueryPerformanceIndexes();
+
+    await migration.up(runner);
+    await runner.release();
+
+    const escrowIndexes = await dataSource.query(`PRAGMA index_list('escrows')`);
+    const userIndexes = await dataSource.query(`PRAGMA index_list('users')`);
+    const eventIndexes = await dataSource.query(`PRAGMA index_list('escrow_events')`);
+
+    expect(escrowIndexes.some((index: { name: string }) => index.name === 'idx_escrows_status')).toBe(true);
+    expect(escrowIndexes.some((index: { name: string }) => index.name === 'idx_escrows_creator_status')).toBe(true);
+    expect(escrowIndexes.some((index: { name: string }) => index.name === 'idx_escrows_created_at')).toBe(true);
+    expect(escrowIndexes.some((index: { name: string }) => index.name === 'idx_escrows_expires_at')).toBe(true);
+    expect(userIndexes.some((index: { name: string }) => index.name === 'idx_users_wallet_address')).toBe(true);
+    expect(eventIndexes.some((index: { name: string }) => index.name === 'idx_escrow_events_escrow_id')).toBe(true);
+
+    const statusPlan = await dataSource.query(
+      `EXPLAIN QUERY PLAN SELECT * FROM escrows WHERE status = 'active'`,
+    );
+    const creatorStatusPlan = await dataSource.query(
+      `EXPLAIN QUERY PLAN SELECT * FROM escrows WHERE creatorId = 'user-1' AND status = 'active'`,
+    );
+    const createdAtPlan = await dataSource.query(
+      `EXPLAIN QUERY PLAN SELECT * FROM escrows WHERE createdAt >= '2026-01-01'`,
+    );
+    const expiresAtPlan = await dataSource.query(
+      `EXPLAIN QUERY PLAN SELECT * FROM escrows WHERE expiresAt <= '2026-12-31'`,
+    );
+    const walletPlan = await dataSource.query(
+      `EXPLAIN QUERY PLAN SELECT * FROM users WHERE walletAddress = 'GABC123'`,
+    );
+    const eventPlan = await dataSource.query(
+      `EXPLAIN QUERY PLAN SELECT * FROM escrow_events WHERE escrowId = 'escrow-1'`,
+    );
+
+    const combinedPlan = [
+      ...statusPlan,
+      ...creatorStatusPlan,
+      ...createdAtPlan,
+      ...expiresAtPlan,
+      ...walletPlan,
+      ...eventPlan,
+    ]
+      .map((row: { detail: string }) => row.detail)
+      .join('\n');
+
+    expect(combinedPlan).toContain('idx_escrows_status');
+    expect(combinedPlan).toContain('idx_escrows_creator_status');
+    expect(combinedPlan).toContain('idx_escrows_created_at');
+    expect(combinedPlan).toContain('idx_escrows_expires_at');
+    expect(combinedPlan).toContain('idx_users_wallet_address');
+    expect(combinedPlan).toContain('idx_escrow_events_escrow_id');
+  });
+});

--- a/apps/backend/src/migrations/1780700000000-AddEscrowQueryPerformanceIndexes.ts
+++ b/apps/backend/src/migrations/1780700000000-AddEscrowQueryPerformanceIndexes.ts
@@ -1,0 +1,35 @@
+import { MigrationInterface, QueryRunner } from 'typeorm';
+
+export class AddEscrowQueryPerformanceIndexes1780700000000 implements MigrationInterface {
+  name = 'AddEscrowQueryPerformanceIndexes1780700000000';
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "idx_escrows_status" ON "escrows" ("status")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "idx_escrows_creator_status" ON "escrows" ("creatorId", "status")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "idx_escrows_created_at" ON "escrows" ("createdAt")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "idx_escrows_expires_at" ON "escrows" ("expiresAt")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "idx_users_wallet_address" ON "users" ("walletAddress")`,
+    );
+    await queryRunner.query(
+      `CREATE INDEX IF NOT EXISTS "idx_escrow_events_escrow_id" ON "escrow_events" ("escrowId")`,
+    );
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX IF EXISTS "idx_escrow_events_escrow_id"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "idx_users_wallet_address"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "idx_escrows_expires_at"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "idx_escrows_created_at"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "idx_escrows_creator_status"`);
+    await queryRunner.query(`DROP INDEX IF EXISTS "idx_escrows_status"`);
+  }
+}


### PR DESCRIPTION
# perf(backend): add database indexing for escrow query performance

This PR adds database indexes for the most common escrow lookup patterns to improve query performance as the dataset grows.

## What changed

- Added an index on escrow status for status-based filtering
- Added a composite index on creator and status for the common filtered lookup pattern
- Added indexes on escrow creation and expiry timestamps for date-range and expiry queries
- Added a wallet-address index for wallet-based party/user lookups
- Added an index on escrow event escrow IDs for event retrieval queries
- Added a migration file covering all requested indexes
- Added a regression test to validate the migration creates the expected indexes

## Testing

- Verified the migration includes all requested index creation statements
- Added a regression test for the new migration

Closes: #486