### PR TITLE
feat(frontend): comprehensive error boundary with retry UX

### DIFF
--- a/apps/frontend/app/dashboard/page.tsx
+++ b/apps/frontend/app/dashboard/page.tsx
@@ -1,10 +1,13 @@
 "use client";
 
 import { Suspense, useCallback, useState } from "react";
+import { QueryErrorResetBoundary } from '@tanstack/react-query';
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
 import StatusTabs from "@/components/dashboard/StatusTabs";
 import EscrowList from "@/components/dashboard/EscrowList";
 import EscrowFilters from "@/components/dashboard/EscrowFilters";
+import { ErrorBoundary } from '@/components/ErrorBoundary';
+import { ErrorFallback } from '@/components/ErrorFallback';
 import { useEscrows } from "../../hooks/useEscrows";
 import ActivityFeed from "@/components/common/ActivityFeed";
 import Link from "next/link";
@@ -81,11 +84,13 @@ function DashboardContent() {
 
   const {
     data: escrowsData,
+    error: escrowsError,
     isLoading,
     isError,
     hasNextPage,
     fetchNextPage,
     isFetchingNextPage,
+    refetch: refetchEscrows,
   } = useEscrows({
     status: activeStatuses.join(","),
     search: searchQuery,
@@ -137,7 +142,18 @@ function DashboardContent() {
               </button>
             </div>
             <div className="flex-1 overflow-y-auto p-4">
-              <ActivityFeed />
+              <ErrorBoundary
+                fallback={({ error, reset }) => (
+                  <ErrorFallback
+                    error={error}
+                    reset={reset}
+                    title="Failed to load activity"
+                    compact
+                  />
+                )}
+              >
+                <ActivityFeed />
+              </ErrorBoundary>
             </div>
           </div>
         </div>
@@ -191,19 +207,41 @@ function DashboardContent() {
             toDate={toDate}
             onDateChange={handleDateChange}
           />
-          <EscrowList
-            escrows={flatEscrows}
-            isLoading={isLoading}
-            isError={isError}
-            activeTab={activeTab}
-            hasNextPage={hasNextPage}
-            fetchNextPage={fetchNextPage}
-            isFetchingNextPage={isFetchingNextPage}
-          />
+          <ErrorBoundary
+            fallback={({ error, reset }) => (
+              <ErrorFallback
+                error={error}
+                reset={reset}
+                title="Failed to load escrows"
+                compact
+              />
+            )}
+          >
+            <EscrowList
+              escrows={flatEscrows}
+              isLoading={isLoading}
+              isError={isError}
+              activeTab={activeTab}
+              hasNextPage={hasNextPage}
+              fetchNextPage={fetchNextPage}
+              isFetchingNextPage={isFetchingNextPage}
+            />
+          </ErrorBoundary>
         </div>
 
         <div className="hidden lg:block lg:col-span-1">
-          <ActivityFeed className="h-[calc(100vh-12rem)] sticky top-8" />
+          <ErrorBoundary
+            fallback={({ error, reset }) => (
+              <ErrorFallback
+                error={error}
+                reset={reset}
+                title="Failed to load activity"
+                compact
+              />
+            )}
+          >
+            <ActivityFeed className="h-[calc(100vh-12rem)] sticky top-8" />
+          </ErrorBoundary>
         </div>
       </div>
     </>
@@ -222,16 +260,35 @@ export default function DashboardPage() {
             Manage all your escrow agreements in one place
           </p>
         </div>
-        <Suspense
-          fallback={
-            <div className="text-center py-20 text-muted-foreground">
-              Loading Dashboard...
-            </div>
-          }
-        >
-          <DashboardContent />
-        </Suspense>
+        <QueryErrorResetBoundary>
+          {({ reset }) => (
+            <ErrorBoundary
+              onReset={reset}
+              fallback={({ error, reset: boundaryReset }) => (
+                <ErrorFallback
+                  error={error}
+                  reset={() => {
+                    reset();
+                    boundaryReset();
+                  }}
+                  title="Failed to load dashboard"
+                />
+              )}
+            >
+              <Suspense
+                fallback={
+                  <div className="text-center py-20 text-muted-foreground">
+                    Loading Dashboard...
+                  </div>
+                }
+              >
+                <DashboardContent />
+              </Suspense>
+            </ErrorBoundary>
+          )}
+        </QueryErrorResetBoundary>
       </div>
     </div>
   );
 }
+

--- a/apps/frontend/components/ErrorBoundary.test.tsx
+++ b/apps/frontend/components/ErrorBoundary.test.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import React from 'react';
+import { render, screen, fireEvent } from '@testing-library/react';
+
+jest.mock('@/lib/errorReporter', () => ({
+  reportError: jest.fn(),
+}));
+
+jest.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: jest.fn(),
+  }),
+}));
+
+import { reportError } from '@/lib/errorReporter';
+import { ErrorBoundary } from './ErrorBoundary';
+
+const ThrowingChild = ({ shouldThrow }: { shouldThrow: boolean }) => {
+  if (shouldThrow) {
+    throw new Error('Test render error');
+  }
+  return <div>Child content rendered</div>;
+};
+
+describe('ErrorBoundary', () => {
+  let consoleErrorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    consoleErrorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    (reportError as jest.Mock).mockClear();
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it('renders children normally when no error occurs', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingChild shouldThrow={false} />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByText('Child content rendered')).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /try again/i })).not.toBeInTheDocument();
+  });
+
+  it('renders the default ErrorFallback when a child throws', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingChild shouldThrow={true} />
+      </ErrorBoundary>,
+    );
+
+    expect(screen.getByRole('button', { name: /try again/i })).toBeInTheDocument();
+    expect(screen.getByText(/try again/i)).toBeInTheDocument();
+  });
+
+  it('resets error state when clicking the Try again button and child no longer throws', () => {
+    const ErrorToggle = () => {
+      const [shouldThrow, setShouldThrow] = React.useState(true);
+      return (
+        <>
+          <ErrorBoundary>
+            <ThrowingChild shouldThrow={shouldThrow} />
+          </ErrorBoundary>
+          <button onClick={() => setShouldThrow(false)}>resolve</button>
+        </>
+      );
+    };
+
+    render(<ErrorToggle />);
+
+    fireEvent.click(screen.getByText('resolve'));
+    fireEvent.click(screen.getByRole('button', { name: /try again/i }));
+
+    expect(screen.getByText('Child content rendered')).toBeInTheDocument();
+  });
+
+  it('uses a custom fallback function when provided', () => {
+    const customFallback = jest.fn(({ error, reset }) => (
+      <div>
+        <p>Custom fallback: {error.message}</p>
+        <button onClick={reset}>Custom retry</button>
+      </div>
+    ));
+
+    render(
+      <ErrorBoundary fallback={customFallback}>
+        <ThrowingChild shouldThrow={true} />
+      </ErrorBoundary>,
+    );
+
+    expect(customFallback).toHaveBeenCalled();
+    expect(customFallback.mock.calls[0][0]).toHaveProperty('error');
+    expect(customFallback.mock.calls[0][0]).toHaveProperty('reset');
+    expect(screen.getByText(/custom fallback/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /custom retry/i })).toBeInTheDocument();
+  });
+
+  it('calls reportError with the error and componentStack when a child throws', () => {
+    render(
+      <ErrorBoundary>
+        <ThrowingChild shouldThrow={true} />
+      </ErrorBoundary>,
+    );
+
+    expect(reportError).toHaveBeenCalledTimes(1);
+    expect(reportError).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({
+        componentStack: expect.any(String),
+      }),
+    );
+  });
+});

--- a/apps/frontend/components/ErrorBoundary.tsx
+++ b/apps/frontend/components/ErrorBoundary.tsx
@@ -2,11 +2,15 @@
 
 import { Component, ErrorInfo, ReactNode } from 'react';
 import { ErrorFallback } from './ErrorFallback';
+import { reportError } from '@/lib/errorReporter';
 
 interface ErrorBoundaryProps {
   children: ReactNode;
-  fallback?: ReactNode;
+  fallback?:
+    | ReactNode
+    | ((props: { error: Error; reset: () => void }) => ReactNode);
   onError?: (error: Error, info: ErrorInfo) => void;
+  onReset?: () => void;
   resetKeys?: Array<unknown>;
 }
 
@@ -28,6 +32,7 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
 
   componentDidCatch(error: Error, info: ErrorInfo) {
     console.error('[ErrorBoundary]', error, info);
+    reportError(error, { componentStack: info.componentStack ?? undefined });
     this.props.onError?.(error, info);
   }
 
@@ -42,13 +47,19 @@ export class ErrorBoundary extends Component<ErrorBoundaryProps, ErrorBoundarySt
   }
 
   reset() {
+    this.props.onReset?.();
     this.setState({ hasError: false, error: null });
   }
 
   render() {
     if (this.state.hasError) {
       if (this.props.fallback) {
-        return this.props.fallback;
+        return typeof this.props.fallback === 'function'
+          ? this.props.fallback({
+              error: this.state.error as Error,
+              reset: this.reset,
+            })
+          : this.props.fallback;
       }
       return (
         <ErrorFallback

--- a/apps/frontend/components/ErrorFallback.tsx
+++ b/apps/frontend/components/ErrorFallback.tsx
@@ -1,21 +1,46 @@
 'use client';
 
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
 import { AlertTriangle, RefreshCw, ExternalLink } from 'lucide-react';
 import { Button } from '@/components/ui/button';
+import { classifyError } from '@/lib/errorUtils';
 
 interface ErrorFallbackProps {
   error: Error & { digest?: string };
   reset: () => void;
   title?: string;
+  compact?: boolean;
 }
 
-export function ErrorFallback({ error, reset, title = 'Something went wrong' }: ErrorFallbackProps) {
+export function ErrorFallback({
+  error,
+  reset,
+  title,
+  compact = false,
+}: ErrorFallbackProps) {
+  const router = useRouter();
+  const { kind, title: kindTitle, description } = classifyError(error);
+  const header = title || kindTitle;
+  const message = error.message || description;
+
+  const primaryLabel = 'Try again';
+  const secondaryLabel = kind === 'auth' ? 'Go Home' : 'Go to Dashboard';
+  const containerClasses = compact
+    ? 'p-6 text-center'
+    : 'min-h-[400px] flex flex-col items-center justify-center p-8 text-center';
+  const iconClasses = compact
+    ? 'w-8 h-8'
+    : 'w-12 h-12';
+
   return (
-    <div className="min-h-[400px] flex flex-col items-center justify-center p-8 text-center">
-      <AlertTriangle className="w-12 h-12 text-amber-500 dark:text-amber-400 mb-4" />
-      <h2 className="text-xl font-semibold text-foreground">{title}</h2>
-      <p className="text-sm text-muted-foreground mt-2 max-w-md line-clamp-3">
-        {error.message || 'An unexpected error occurred.'}
+    <div className={containerClasses}>
+      <AlertTriangle
+        className={`${iconClasses} text-amber-500 dark:text-amber-400 mb-4`}
+      />
+      <h2 className="text-xl font-semibold text-foreground">{header}</h2>
+      <p className="text-sm text-muted-foreground mt-2 max-w-md">
+        {message}
       </p>
       {error.digest && (
         <code className="mt-3 inline-block bg-muted text-muted-foreground text-xs rounded px-2 py-1 font-mono">
@@ -25,9 +50,16 @@ export function ErrorFallback({ error, reset, title = 'Something went wrong' }: 
       <div className="mt-6 flex gap-3 flex-wrap justify-center">
         <Button size="sm" onClick={reset}>
           <RefreshCw className="mr-1.5 h-4 w-4" />
-          Try again
+          {primaryLabel}
         </Button>
-        <Button size="sm" variant="outline" asChild>
+        <Button
+          size="sm"
+          variant="outline"
+          onClick={() => router.push(kind === 'auth' ? '/' : '/dashboard')}
+        >
+          {secondaryLabel}
+        </Button>
+        <Button size="sm" variant="ghost" asChild>
           <a
             href="https://github.com/zhero-o/Vaultix/issues/new"
             target="_blank"
@@ -37,6 +69,11 @@ export function ErrorFallback({ error, reset, title = 'Something went wrong' }: 
             Report issue
           </a>
         </Button>
+        {kind !== 'auth' && (
+          <Button size="sm" variant="secondary" asChild>
+            <Link href="/">Go Home</Link>
+          </Button>
+        )}
       </div>
     </div>
   );

--- a/apps/frontend/components/dashboard/EscrowList.tsx
+++ b/apps/frontend/components/dashboard/EscrowList.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import Link from 'next/link';
+import { Button } from '@/components/ui/button';
 import EscrowCard from './EscrowCard';
 import { EscrowCardSkeleton } from '@/components/ui/EscrowCardSkeleton';
+import { ErrorFallback } from '@/components/ErrorFallback';
 
 // Define the interface here since we can't import from types yet
 interface IEscrow {
@@ -28,6 +30,8 @@ interface EscrowListProps {
   escrows: IEscrow[];
   isLoading: boolean;
   isError: boolean;
+  error?: unknown;
+  refetch?: () => void;
   activeTab: 'all' | 'active' | 'pending' | 'completed' | 'disputed';
   hasNextPage?: boolean;
   fetchNextPage?: () => void;
@@ -38,6 +42,8 @@ const EscrowList: React.FC<EscrowListProps> = ({
   escrows,
   isLoading,
   isError,
+  error,
+  refetch,
   activeTab,
   hasNextPage,
   fetchNextPage,
@@ -58,10 +64,20 @@ const EscrowList: React.FC<EscrowListProps> = ({
   // Show error state
   if (isError) {
     return (
-      <div className="text-center py-10">
-        <h3 className="text-lg font-medium text-red-600">Error Loading Escrows</h3>
-        <p className="text-gray-500 mt-2">There was an issue retrieving your escrow agreements. Please try again later.</p>
-      </div>
+      <ErrorFallback
+        error={
+          error instanceof Error
+            ? error
+            : new Error(
+                typeof error === 'string'
+                  ? error
+                  : 'Failed to load escrows',
+              )
+        }
+        reset={() => refetch?.()}
+        title="Failed to load escrows"
+        compact
+      />
     );
   }
 

--- a/apps/frontend/hooks/useErrorReporter.ts
+++ b/apps/frontend/hooks/useErrorReporter.ts
@@ -1,0 +1,13 @@
+'use client';
+
+import { useCallback } from 'react';
+import { reportError, ErrorReportInfo } from '@/lib/errorReporter';
+
+export function useErrorReporter() {
+  return useCallback(
+    (error: unknown, info?: ErrorReportInfo) => {
+      reportError(error, info);
+    },
+    [],
+  );
+}

--- a/apps/frontend/lib/errorReporter.ts
+++ b/apps/frontend/lib/errorReporter.ts
@@ -1,0 +1,10 @@
+'use client';
+
+export interface ErrorReportInfo {
+  componentStack?: string;
+}
+
+export function reportError(error: unknown, info?: ErrorReportInfo) {
+  // This is a placeholder for an error reporting integration such as Sentry.
+  console.warn('[ErrorReporter]', error, info);
+}

--- a/apps/frontend/lib/errorUtils.ts
+++ b/apps/frontend/lib/errorUtils.ts
@@ -1,0 +1,90 @@
+'use client';
+
+export type ErrorKind = 'network' | 'auth' | 'server' | 'unknown';
+
+export interface ErrorClassification {
+  kind: ErrorKind;
+  title: string;
+  description: string;
+}
+
+const getMessage = (error: unknown): string => {
+  if (error instanceof Error) return error.message;
+  if (typeof error === 'string') return error;
+  if (typeof error === 'object' && error !== null) {
+    const typedError = error as Record<string, unknown>;
+    if (typeof typedError.message === 'string') return typedError.message;
+    if (typeof typedError.error === 'string') return typedError.error;
+  }
+  return 'An unexpected error occurred.';
+};
+
+const getStatusCode = (error: unknown): number | undefined => {
+  if (typeof error === 'object' && error !== null) {
+    const typedError = error as Record<string, unknown>;
+    const statusValue = typedError.status ?? typedError.statusCode ?? typedError.code;
+    if (typeof statusValue === 'number') return statusValue;
+    if (typeof statusValue === 'string' && /^\\\d{3}\\b$/.test(statusValue)) {
+      return Number(statusValue);
+    }
+  }
+
+  const message = getMessage(error);
+  const match = message.match(/HTTP\s*(\d{3})/i) || message.match(/\b(\d{3})\b/);
+  if (match) {
+    return Number(match[1]);
+  }
+
+  return undefined;
+};
+
+const isNetworkError = (message: string) => {
+  const lower = message.toLowerCase();
+  return (
+    lower.includes('failed to fetch') ||
+    lower.includes('networkerror') ||
+    lower.includes('network request failed') ||
+    lower.includes('connection refused') ||
+    lower.includes('socket hang up') ||
+    lower.includes('timeout')
+  );
+};
+
+export function classifyError(error: unknown): ErrorClassification {
+  const message = getMessage(error);
+  const status = getStatusCode(error);
+
+  if (isNetworkError(message)) {
+    return {
+      kind: 'network',
+      title: 'Network issue detected',
+      description:
+        'We had trouble connecting to the server. Check your network and try again.',
+    };
+  }
+
+  if (status === 401 || status === 403 || /unauthori[sz]ed|permission denied/i.test(message)) {
+    return {
+      kind: 'auth',
+      title: 'Authentication required',
+      description:
+        'Your session may have expired or you do not have access. Sign in again to continue.',
+    };
+  }
+
+  if ((status && status >= 500) || /server error|internal error|bad gateway/i.test(message)) {
+    return {
+      kind: 'server',
+      title: 'Server error occurred',
+      description:
+        'The server encountered an issue. Please try again shortly.',
+    };
+  }
+
+  return {
+    kind: 'unknown',
+    title: 'Something went wrong',
+    description:
+      'An unexpected error occurred. You can try again or return to a safe page.',
+  };
+}


### PR DESCRIPTION
Summary
- Categorize errors into network/auth/server/unknown (lib/errorUtils.ts)
- Add error reporting hook stub for future Sentry integration (lib/errorReporter.ts, hooks/useErrorReporter.ts)
- Enhance ErrorFallback with contextual messages, retry, and Dashboard/Home navigation
- Wire QueryErrorResetBoundary into dashboard for React Query cache reset on retry
- Add section-level ErrorBoundary isolation for EscrowList and ActivityFeed so a failure in one doesn't crash the whole dashboard
- Connect EscrowList's React Query isError state to the shared ErrorFallback/classifyError system
- Add ErrorBoundary test coverage (reset, custom fallback, error reporting)

Closes #498