### PR TITLE
feat(frontend): add skeleton loading states to all data-heavy pages

### DIFF
--- a/apps/frontend/app/admin/disputes/page.tsx
+++ b/apps/frontend/app/admin/disputes/page.tsx
@@ -1,6 +1,6 @@
-'use client';
+"use client";
 
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef } from "react";
 import {
   AlertTriangle,
   Clock,
@@ -18,23 +18,24 @@ import {
   ChevronRight,
   Shield,
   FileCode,
-} from 'lucide-react';
-import { AdminService } from '@/services/admin';
-import { IAdminDispute } from '@/types/admin';
-import { toast } from 'sonner';
+} from "lucide-react";
+import { AdminService } from "@/services/admin";
+import { IAdminDispute } from "@/types/admin";
+import { toast } from "sonner";
+import { AdminDisputesSkeleton } from "@/components/ui/AdminDisputesSkeleton";
 
 export default function AdminDisputesPage() {
   const [disputes, setDisputes] = useState<IAdminDispute[]>([]);
   const [selectedDispute, setSelectedDispute] = useState<IAdminDispute | null>(null);
   const [loading, setLoading] = useState(true);
-  const [sortBy, setSortBy] = useState<'oldest' | 'newest' | 'most_evidence' | 'highest_amount'>('oldest');
-  
+  const [sortBy, setSortBy] = useState<"oldest" | "newest" | "most_evidence" | "highest_amount">("oldest");
+
   // Resolution form states
-  const [outcome, setOutcome] = useState<'released_to_seller' | 'refunded_to_buyer' | 'split'>('released_to_seller');
-  const [resolutionNotes, setResolutionNotes] = useState('');
+  const [outcome, setOutcome] = useState<"released_to_seller" | "refunded_to_buyer" | "split">("released_to_seller");
+  const [resolutionNotes, setResolutionNotes] = useState("");
   const [sellerPercent, setSellerPercent] = useState<number>(50);
   const [buyerPercent, setBuyerPercent] = useState<number>(50);
-  
+
   // Confirmation dialog state
   const [showConfirmModal, setShowConfirmModal] = useState(false);
   const [submitting, setSubmitting] = useState(false);
@@ -49,20 +50,20 @@ export default function AdminDisputesPage() {
   const loadDisputes = async () => {
     try {
       setLoading(true);
-      const res = await AdminService.getDisputes({ status: 'open', sortBy });
+      const res = await AdminService.getDisputes({ status: "open", sortBy });
       setDisputes(res.disputes);
-      
+
       // Auto-select first dispute if none selected and on desktop
       if (res.disputes.length > 0 && !selectedDispute) {
         setSelectedDispute(res.disputes[0]);
       } else if (selectedDispute) {
         // Refresh selected dispute details
-        const updatedSelected = res.disputes.find(d => d.id === selectedDispute.id);
+        const updatedSelected = res.disputes.find((d) => d.id === selectedDispute.id);
         setSelectedDispute(updatedSelected || res.disputes[0] || null);
       }
     } catch (error) {
-      console.error('Error fetching disputes:', error);
-      toast.error('Failed to load disputes');
+      console.error("Error fetching disputes:", error);
+      toast.error("Failed to load disputes");
     } finally {
       setLoading(false);
     }
@@ -73,52 +74,52 @@ export default function AdminDisputesPage() {
     const handleKeyDown = (e: KeyboardEvent) => {
       // Don't trigger shortcuts when user is typing
       if (
-        document.activeElement?.tagName === 'INPUT' ||
-        document.activeElement?.tagName === 'TEXTAREA' ||
-        document.activeElement?.getAttribute('contenteditable') === 'true'
+        document.activeElement?.tagName === "INPUT" ||
+        document.activeElement?.tagName === "TEXTAREA" ||
+        document.activeElement?.getAttribute("contenteditable") === "true"
       ) {
         return;
       }
 
-      if (e.key === 'r' || e.key === 'R') {
+      if (e.key === "r" || e.key === "R") {
         e.preventDefault();
         notesInputRef.current?.focus();
-        toast.info('Form focused (Shortcut R)');
-      } else if (e.key === 'b' || e.key === 'B') {
+        toast.info("Form focused (Shortcut R)");
+      } else if (e.key === "b" || e.key === "B") {
         e.preventDefault();
-        setOutcome('refunded_to_buyer');
-        toast.info('Outcome set to Refund Buyer (Shortcut B)');
-      } else if (e.key === 's' || e.key === 'S') {
+        setOutcome("refunded_to_buyer");
+        toast.info("Outcome set to Refund Buyer (Shortcut B)");
+      } else if (e.key === "s" || e.key === "S") {
         e.preventDefault();
-        setOutcome('released_to_seller');
-        toast.info('Outcome set to Pay Seller (Shortcut S)');
+        setOutcome("released_to_seller");
+        toast.info("Outcome set to Pay Seller (Shortcut S)");
       }
     };
 
-    window.addEventListener('keydown', handleKeyDown);
-    return () => window.removeEventListener('keydown', handleKeyDown);
+    window.addEventListener("keydown", handleKeyDown);
+    return () => window.removeEventListener("keydown", handleKeyDown);
   }, [selectedDispute]);
 
   const getPriority = (amountStr: string, createdAt: string) => {
     const amount = parseFloat(amountStr);
     const ageDays = (Date.now() - new Date(createdAt).getTime()) / (24 * 60 * 60 * 1000);
     if (amount >= 10000 || ageDays >= 7) {
-      return { label: 'High', color: 'text-red-400 bg-red-500/10 border-red-500/20' };
+      return { label: "High", color: "text-red-400 bg-red-500/10 border-red-500/20" };
     }
     if (amount >= 1000 || ageDays >= 3) {
-      return { label: 'Medium', color: 'text-amber-400 bg-amber-500/10 border-amber-500/20' };
+      return { label: "Medium", color: "text-amber-400 bg-amber-500/10 border-amber-500/20" };
     }
-    return { label: 'Low', color: 'text-emerald-400 bg-emerald-500/10 border-emerald-500/20' };
+    return { label: "Low", color: "text-emerald-400 bg-emerald-500/10 border-emerald-500/20" };
   };
 
   const handleOpenConfirm = (e: React.FormEvent) => {
     e.preventDefault();
     if (!resolutionNotes.trim()) {
-      toast.error('Resolution notes are required');
+      toast.error("Resolution notes are required");
       return;
     }
-    if (outcome === 'split' && sellerPercent + buyerPercent !== 100) {
-      toast.error('Split percentages must sum to 100%');
+    if (outcome === "split" && sellerPercent + buyerPercent !== 100) {
+      toast.error("Split percentages must sum to 100%");
       return;
     }
     setShowConfirmModal(true);
@@ -131,16 +132,16 @@ export default function AdminDisputesPage() {
       await AdminService.resolveDispute(selectedDispute.id, {
         outcome,
         resolutionNotes,
-        sellerPercent: outcome === 'split' ? sellerPercent : undefined,
-        buyerPercent: outcome === 'split' ? buyerPercent : undefined,
+        sellerPercent: outcome === "split" ? sellerPercent : undefined,
+        buyerPercent: outcome === "split" ? buyerPercent : undefined,
       });
 
-      toast.success('Dispute resolved successfully');
-      setResolutionNotes('');
+      toast.success("Dispute resolved successfully");
+      setResolutionNotes("");
       setShowConfirmModal(false);
-      
+
       // Reload
-      const res = await AdminService.getDisputes({ status: 'open', sortBy });
+      const res = await AdminService.getDisputes({ status: "open", sortBy });
       setDisputes(res.disputes);
       if (res.disputes.length > 0) {
         setSelectedDispute(res.disputes[0]);
@@ -148,8 +149,8 @@ export default function AdminDisputesPage() {
         setSelectedDispute(null);
       }
     } catch (error) {
-      console.error('Error resolving dispute:', error);
-      toast.error('Failed to resolve dispute');
+      console.error("Error resolving dispute:", error);
+      toast.error("Failed to resolve dispute");
     } finally {
       setSubmitting(false);
     }
@@ -174,9 +175,7 @@ export default function AdminDisputesPage() {
             <Scale className="text-purple-400 w-7 h-7" />
             Dispute Resolution
           </h1>
-          <p className="text-sm text-gray-500 mt-1">
-            Review evidence, communicate log, and resolve conflicts between parties.
-          </p>
+          <p className="text-sm text-gray-500 mt-1">Review evidence, communicate log, and resolve conflicts between parties.</p>
         </div>
 
         {/* Sort Controls */}
@@ -196,29 +195,19 @@ export default function AdminDisputesPage() {
       </div>
 
       {loading && disputes.length === 0 ? (
-        <div className="flex items-center justify-center min-h-[50vh]">
-          <div className="flex flex-col items-center gap-3">
-            <Loader2 className="w-8 h-8 text-purple-500 animate-spin" />
-            <p className="text-sm text-gray-500">Loading open disputes...</p>
-          </div>
-        </div>
+        <AdminDisputesSkeleton />
       ) : disputes.length === 0 ? (
         <div className="bg-[#12121a] border border-white/5 rounded-xl p-12 text-center">
           <Scale className="w-16 h-16 text-gray-700 mx-auto mb-4" />
           <h2 className="text-lg font-semibold text-white">No Open Disputes</h2>
-          <p className="text-sm text-gray-500 mt-1 max-w-md mx-auto">
-            All disputes have been successfully resolved. Great job!
-          </p>
+          <p className="text-sm text-gray-500 mt-1 max-w-md mx-auto">All disputes have been successfully resolved. Great job!</p>
         </div>
       ) : (
         /* Split view grid */
         <div className="grid grid-cols-1 lg:grid-cols-12 gap-6 items-start">
-          
           {/* LEFT LIST: visible or hidden on mobile depending on selected state */}
-          <div className={`lg:col-span-4 space-y-4 ${selectedDispute ? 'hidden lg:block' : 'block'}`}>
-            <h2 className="text-sm font-semibold text-gray-400 px-1">
-              Open Cases ({disputes.length})
-            </h2>
+          <div className={`lg:col-span-4 space-y-4 ${selectedDispute ? "hidden lg:block" : "block"}`}>
+            <h2 className="text-sm font-semibold text-gray-400 px-1">Open Cases ({disputes.length})</h2>
             <div className="space-y-3 overflow-y-auto max-h-[75vh] pr-1">
               {disputes.map((dispute) => {
                 const priority = getPriority(dispute.escrow.amount, dispute.createdAt);
@@ -228,18 +217,12 @@ export default function AdminDisputesPage() {
                     key={dispute.id}
                     onClick={() => setSelectedDispute(dispute)}
                     className={`w-full text-left rounded-xl p-4 border transition-all duration-200 block ${
-                      isSelected
-                        ? 'bg-purple-950/20 border-purple-500/50 shadow-lg shadow-purple-500/5'
-                        : 'bg-[#12121a] border-white/5 hover:border-white/10'
+                      isSelected ? "bg-purple-950/20 border-purple-500/50 shadow-lg shadow-purple-500/5" : "bg-[#12121a] border-white/5 hover:border-white/10"
                     }`}
                   >
                     <div className="flex items-start justify-between gap-3 mb-2">
-                      <h3 className="font-semibold text-sm text-white truncate flex-1">
-                        {dispute.escrow.title}
-                      </h3>
-                      <span className={`text-[10px] font-bold px-2 py-0.5 rounded-full border ${priority.color}`}>
-                        {priority.label}
-                      </span>
+                      <h3 className="font-semibold text-sm text-white truncate flex-1">{dispute.escrow.title}</h3>
+                      <span className={`text-[10px] font-bold px-2 py-0.5 rounded-full border ${priority.color}`}>{priority.label}</span>
                     </div>
 
                     <div className="flex justify-between items-center text-xs mt-3">
@@ -259,14 +242,10 @@ export default function AdminDisputesPage() {
 
           {/* RIGHT DETAIL SPLIT: visible on desktop, mobile list-to-detail toggle */}
           {selectedDispute && (
-            <div className={`lg:col-span-8 grid grid-cols-1 md:grid-cols-12 gap-6 ${selectedDispute ? 'block' : 'hidden lg:block'}`}>
-              
+            <div className={`lg:col-span-8 grid grid-cols-1 md:grid-cols-12 gap-6 ${selectedDispute ? "block" : "hidden lg:block"}`}>
               {/* Back button for mobile detail view */}
               <div className="col-span-12 lg:hidden">
-                <button
-                  onClick={() => setSelectedDispute(null)}
-                  className="flex items-center gap-2 text-xs text-gray-400 hover:text-white"
-                >
+                <button onClick={() => setSelectedDispute(null)} className="flex items-center gap-2 text-xs text-gray-400 hover:text-white">
                   <ArrowLeft className="w-4 h-4" />
                   Back to Open Disputes
                 </button>
@@ -274,7 +253,6 @@ export default function AdminDisputesPage() {
 
               {/* Detail view left (Escrow Info + Evidence + Timeline + Chat) */}
               <div className="col-span-12 md:col-span-7 space-y-6">
-                
                 {/* Real-time Escrow details card */}
                 <div className="bg-[#12121a] border border-white/5 rounded-xl p-5 space-y-4">
                   <div className="flex items-center justify-between border-b border-white/5 pb-3">
@@ -284,9 +262,7 @@ export default function AdminDisputesPage() {
 
                   <div>
                     <h3 className="text-lg font-semibold text-white">{selectedDispute.escrow.title}</h3>
-                    <p className="text-xs text-gray-400 mt-1 leading-relaxed">
-                      {selectedDispute.escrow.description}
-                    </p>
+                    <p className="text-xs text-gray-400 mt-1 leading-relaxed">{selectedDispute.escrow.description}</p>
                   </div>
 
                   <div className="grid grid-cols-2 gap-4 bg-white/[0.02] rounded-lg p-3 text-xs">
@@ -298,18 +274,14 @@ export default function AdminDisputesPage() {
                     </div>
                     <div>
                       <p className="text-gray-500">Dispute Raised By</p>
-                      <p className="text-sm font-medium text-gray-300 mt-0.5 truncate">
-                        {selectedDispute.filedBy.walletAddress}
-                      </p>
+                      <p className="text-sm font-medium text-gray-300 mt-0.5 truncate">{selectedDispute.filedBy.walletAddress}</p>
                     </div>
                   </div>
 
                   {/* Reason & Evidence */}
                   <div className="space-y-2">
                     <span className="text-xs text-gray-500 font-medium block">Reason for Dispute</span>
-                    <p className="text-xs text-gray-300 bg-red-500/5 border border-red-500/10 rounded-lg p-3 leading-relaxed">
-                      {selectedDispute.reason}
-                    </p>
+                    <p className="text-xs text-gray-300 bg-red-500/5 border border-red-500/10 rounded-lg p-3 leading-relaxed">{selectedDispute.reason}</p>
                   </div>
 
                   {selectedDispute.evidence && selectedDispute.evidence.length > 0 && (
@@ -319,23 +291,13 @@ export default function AdminDisputesPage() {
                         {selectedDispute.evidence.map((ev, idx) => {
                           const isImage = ev.match(/\.(jpg|jpeg|png|webp)(\?.*)?$/i);
                           return (
-                            <div
-                              key={idx}
-                              className="bg-white/[0.02] border border-white/5 rounded-lg overflow-hidden hover:bg-white/[0.04] transition-colors"
-                            >
+                            <div key={idx} className="bg-white/[0.02] border border-white/5 rounded-lg overflow-hidden hover:bg-white/[0.04] transition-colors">
                               {isImage ? (
                                 <div className="relative group">
                                   {/* eslint-disable-next-line @next/next/no-img-element */}
-                                  <img
-                                    src={ev}
-                                    alt={`Evidence ${idx + 1}`}
-                                    className="w-full h-24 object-cover"
-                                  />
+                                  <img src={ev} alt={`Evidence ${idx + 1}`} className="w-full h-24 object-cover" />
                                   <div className="absolute inset-0 bg-black/50 opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center">
-                                    <button
-                                      onClick={() => toast.info(`Viewing evidence: ${ev}`)}
-                                      className="text-white text-xs font-medium"
-                                    >
+                                    <button onClick={() => toast.info(`Viewing evidence: ${ev}`)} className="text-white text-xs font-medium">
                                       View
                                     </button>
                                   </div>
@@ -349,11 +311,8 @@ export default function AdminDisputesPage() {
                                 </div>
                               )}
                               <div className="px-2 pb-2">
-                                <button
-                                  onClick={() => toast.info(`Viewing evidence: ${ev}`)}
-                                  className="text-purple-400 hover:text-purple-300 font-medium text-[11px]"
-                                >
-                                  {isImage ? 'View Full' : 'Open Link'}
+                                <button onClick={() => toast.info(`Viewing evidence: ${ev}`)} className="text-purple-400 hover:text-purple-300 font-medium text-[11px]">
+                                  {isImage ? "View Full" : "Open Link"}
                                 </button>
                               </div>
                             </div>
@@ -370,16 +329,14 @@ export default function AdminDisputesPage() {
                     <MessageSquare className="w-4 h-4 text-purple-400" />
                     Communication Log
                   </h3>
-                  
+
                   {selectedDispute.communicationLog && selectedDispute.communicationLog.length > 0 ? (
                     <div className="space-y-3 max-h-56 overflow-y-auto pr-1">
                       {selectedDispute.communicationLog.map((chat) => (
                         <div key={chat.id} className="bg-white/[0.01] border border-white/5 rounded-lg p-3 space-y-1">
                           <div className="flex justify-between items-center text-[10px]">
                             <span className="font-semibold text-purple-300">{chat.sender}</span>
-                            <span className="text-gray-500">
-                              {new Date(chat.timestamp).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
-                            </span>
+                            <span className="text-gray-500">{new Date(chat.timestamp).toLocaleTimeString([], { hour: "2-digit", minute: "2-digit" })}</span>
                           </div>
                           <p className="text-xs text-gray-300 leading-relaxed">{chat.message}</p>
                         </div>
@@ -401,19 +358,11 @@ export default function AdminDisputesPage() {
                       {selectedDispute.resolutionHistory.map((hist, idx) => (
                         <div key={idx} className="border-l-2 border-purple-500/50 pl-3 py-1 space-y-1">
                           <div className="flex justify-between items-center text-xs">
-                            <span className="font-semibold text-gray-300 capitalize">
-                              Outcome: {hist.outcome.replace(/_/g, ' ')}
-                            </span>
-                            <span className="text-[10px] text-gray-500">
-                              {new Date(hist.resolvedAt).toLocaleDateString()}
-                            </span>
+                            <span className="font-semibold text-gray-300 capitalize">Outcome: {hist.outcome.replace(/_/g, " ")}</span>
+                            <span className="text-[10px] text-gray-500">{new Date(hist.resolvedAt).toLocaleDateString()}</span>
                           </div>
-                          <p className="text-xs text-gray-400 leading-relaxed">
-                            {hist.notes}
-                          </p>
-                          <p className="text-[10px] text-purple-400/80">
-                            Arbitrator: {hist.resolvedBy}
-                          </p>
+                          <p className="text-xs text-gray-400 leading-relaxed">{hist.notes}</p>
+                          <p className="text-[10px] text-purple-400/80">Arbitrator: {hist.resolvedBy}</p>
                         </div>
                       ))}
                     </div>
@@ -433,9 +382,7 @@ export default function AdminDisputesPage() {
                         <div className="flex-1 pb-2">
                           <div className="flex items-center justify-between">
                             <span className="font-semibold text-gray-300">{item.title}</span>
-                            <span className="text-[10px] text-gray-500">
-                              {new Date(item.timestamp).toLocaleDateString()}
-                            </span>
+                            <span className="text-[10px] text-gray-500">{new Date(item.timestamp).toLocaleDateString()}</span>
                           </div>
                           <p className="text-gray-500 mt-0.5">{item.description}</p>
                           <span className="text-[10px] text-purple-400/70 mt-1 block">Actor: {item.actor}</span>
@@ -444,7 +391,6 @@ export default function AdminDisputesPage() {
                     ))}
                   </div>
                 </div>
-
               </div>
 
               {/* Detail view right (Resolution form) */}
@@ -453,7 +399,8 @@ export default function AdminDisputesPage() {
                   <div>
                     <h3 className="text-sm font-semibold text-white">Arbitration Resolution</h3>
                     <p className="text-[10px] text-gray-500 mt-0.5">
-                      Keyboard shortcuts: <kbd className="bg-white/5 px-1 rounded text-[9px]">R</kbd>=Focus notes, <kbd className="bg-white/5 px-1 rounded text-[9px]">B</kbd>=Buyer wins, <kbd className="bg-white/5 px-1 rounded text-[9px]">S</kbd>=Seller wins
+                      Keyboard shortcuts: <kbd className="bg-white/5 px-1 rounded text-[9px]">R</kbd>=Focus notes,{" "}
+                      <kbd className="bg-white/5 px-1 rounded text-[9px]">B</kbd>=Buyer wins, <kbd className="bg-white/5 px-1 rounded text-[9px]">S</kbd>=Seller wins
                     </p>
                   </div>
 
@@ -464,45 +411,43 @@ export default function AdminDisputesPage() {
                       <div className="grid grid-cols-1 gap-2">
                         <button
                           type="button"
-                          onClick={() => setOutcome('released_to_seller')}
+                          onClick={() => setOutcome("released_to_seller")}
                           className={`flex items-center justify-between p-3 rounded-lg border text-xs text-left transition-colors ${
-                            outcome === 'released_to_seller'
-                              ? 'bg-purple-950/20 border-purple-500 text-white'
-                              : 'bg-white/[0.02] border-white/5 text-gray-400 hover:border-white/10'
+                            outcome === "released_to_seller"
+                              ? "bg-purple-950/20 border-purple-500 text-white"
+                              : "bg-white/[0.02] border-white/5 text-gray-400 hover:border-white/10"
                           }`}
                         >
                           <span>Pay Seller (100%)</span>
-                          {outcome === 'released_to_seller' && <Check className="w-4 h-4 text-purple-400" />}
+                          {outcome === "released_to_seller" && <Check className="w-4 h-4 text-purple-400" />}
                         </button>
                         <button
                           type="button"
-                          onClick={() => setOutcome('refunded_to_buyer')}
+                          onClick={() => setOutcome("refunded_to_buyer")}
                           className={`flex items-center justify-between p-3 rounded-lg border text-xs text-left transition-colors ${
-                            outcome === 'refunded_to_buyer'
-                              ? 'bg-purple-950/20 border-purple-500 text-white'
-                              : 'bg-white/[0.02] border-white/5 text-gray-400 hover:border-white/10'
+                            outcome === "refunded_to_buyer"
+                              ? "bg-purple-950/20 border-purple-500 text-white"
+                              : "bg-white/[0.02] border-white/5 text-gray-400 hover:border-white/10"
                           }`}
                         >
                           <span>Refund Buyer (100%)</span>
-                          {outcome === 'refunded_to_buyer' && <Check className="w-4 h-4 text-purple-400" />}
+                          {outcome === "refunded_to_buyer" && <Check className="w-4 h-4 text-purple-400" />}
                         </button>
                         <button
                           type="button"
-                          onClick={() => setOutcome('split')}
+                          onClick={() => setOutcome("split")}
                           className={`flex items-center justify-between p-3 rounded-lg border text-xs text-left transition-colors ${
-                            outcome === 'split'
-                              ? 'bg-purple-950/20 border-purple-500 text-white'
-                              : 'bg-white/[0.02] border-white/5 text-gray-400 hover:border-white/10'
+                            outcome === "split" ? "bg-purple-950/20 border-purple-500 text-white" : "bg-white/[0.02] border-white/5 text-gray-400 hover:border-white/10"
                           }`}
                         >
                           <span>Custom Split (%)</span>
-                          {outcome === 'split' && <Check className="w-4 h-4 text-purple-400" />}
+                          {outcome === "split" && <Check className="w-4 h-4 text-purple-400" />}
                         </button>
                       </div>
                     </div>
 
                     {/* Custom Split Sliders */}
-                    {outcome === 'split' && (
+                    {outcome === "split" && (
                       <div className="space-y-3 bg-white/[0.02] border border-white/5 rounded-lg p-3 text-xs">
                         <div className="space-y-1.5">
                           <div className="flex justify-between">
@@ -559,26 +504,21 @@ export default function AdminDisputesPage() {
                   </form>
                 </div>
               </div>
-
             </div>
           )}
-
         </div>
       )}
 
       {/* Confirmation Dialog Modal */}
       {showConfirmModal && selectedDispute && (
         <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-          <div
-            className="absolute inset-0 bg-black/60 backdrop-blur-sm"
-            onClick={() => setShowConfirmModal(false)}
-          />
+          <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" onClick={() => setShowConfirmModal(false)} />
           <div className="relative bg-[#12121a] border border-white/10 rounded-xl p-6 max-w-md w-full shadow-2xl space-y-4">
             <h3 className="text-base font-bold text-white flex items-center gap-2">
               <AlertTriangle className="text-amber-500 w-5 h-5" />
               Confirm Arbitration Ruling
             </h3>
-            
+
             <p className="text-xs text-gray-400 leading-relaxed">
               Are you sure you want to finalize this resolution? This action will transfer on-chain funds accordingly and close the dispute. It cannot be undone.
             </p>
@@ -591,7 +531,7 @@ export default function AdminDisputesPage() {
               <div className="flex justify-between">
                 <span>Outcome:</span>
                 <span className="font-semibold text-purple-400 capitalize">
-                  {outcome === 'split' ? `Custom Split (B:${buyerPercent}% / S:${sellerPercent}%)` : outcome.replace(/_/g, ' ')}
+                  {outcome === "split" ? `Custom Split (B:${buyerPercent}% / S:${sellerPercent}%)` : outcome.replace(/_/g, " ")}
                 </span>
               </div>
             </div>

--- a/apps/frontend/app/admin/escrows/page.tsx
+++ b/apps/frontend/app/admin/escrows/page.tsx
@@ -1,23 +1,21 @@
-'use client';
+"use client";
 
-import React, { useState, useEffect, useCallback } from 'react';
-import {
-  Filter, ChevronLeft, ChevronRight, Eye, RefreshCw, X,
-  Loader2, AlertCircle, CheckCircle2, Clock, XCircle, AlertTriangle, Download,
-} from 'lucide-react';
-import { AdminService } from '@/services/admin';
-import { IAdminEscrow, IAdminEscrowResponse } from '@/types/admin';
-import { ExportDropdown, ExportFormat } from '@/components/ExportDropdown';
-import { ExportModal } from '@/components/ExportModal';
-import { useToast } from '@/hooks/useToast';
-import EscrowTimeline from '@/components/escrow/EscrowTimeline';
+import React, { useState, useEffect, useCallback } from "react";
+import { Filter, ChevronLeft, ChevronRight, Eye, RefreshCw, X, Loader2, AlertCircle, CheckCircle2, Clock, XCircle, AlertTriangle, Download } from "lucide-react";
+import { AdminService } from "@/services/admin";
+import { IAdminEscrow, IAdminEscrowResponse } from "@/types/admin";
+import { ExportDropdown, ExportFormat } from "@/components/ExportDropdown";
+import { ExportModal } from "@/components/ExportModal";
+import { useToast } from "@/hooks/useToast";
+import EscrowTimeline from "@/components/escrow/EscrowTimeline";
+import { AdminTableSkeleton } from "@/components/ui/AdminTableSkeleton";
 
 const STATUS_CONFIG: Record<string, { color: string; bg: string; icon: React.ElementType }> = {
-  ACTIVE: { color: 'text-emerald-400', bg: 'bg-emerald-500/10', icon: CheckCircle2 },
-  COMPLETED: { color: 'text-blue-400', bg: 'bg-blue-500/10', icon: CheckCircle2 },
-  PENDING: { color: 'text-yellow-400', bg: 'bg-yellow-500/10', icon: Clock },
-  CANCELLED: { color: 'text-gray-400', bg: 'bg-gray-500/10', icon: XCircle },
-  DISPUTED: { color: 'text-red-400', bg: 'bg-red-500/10', icon: AlertTriangle },
+  ACTIVE: { color: "text-emerald-400", bg: "bg-emerald-500/10", icon: CheckCircle2 },
+  COMPLETED: { color: "text-blue-400", bg: "bg-blue-500/10", icon: CheckCircle2 },
+  PENDING: { color: "text-yellow-400", bg: "bg-yellow-500/10", icon: Clock },
+  CANCELLED: { color: "text-gray-400", bg: "bg-gray-500/10", icon: XCircle },
+  DISPUTED: { color: "text-red-400", bg: "bg-red-500/10", icon: AlertTriangle },
 };
 
 function StatusBadge({ status }: { status: string }) {
@@ -31,9 +29,7 @@ function StatusBadge({ status }: { status: string }) {
   );
 }
 
-function EscrowDetailModal({ escrow, onClose, onConsistencyCheck }: {
-  escrow: IAdminEscrow; onClose: () => void; onConsistencyCheck: (id: string) => void;
-}) {
+function EscrowDetailModal({ escrow, onClose, onConsistencyCheck }: { escrow: IAdminEscrow; onClose: () => void; onConsistencyCheck: (id: string) => void }) {
   const [checking, setChecking] = useState(false);
   const [result, setResult] = useState<{ status: string; issues: string[] } | null>(null);
 
@@ -63,12 +59,24 @@ function EscrowDetailModal({ escrow, onClose, onConsistencyCheck }: {
             <p className="text-white font-medium">{escrow.title}</p>
           </div>
           <div className="grid grid-cols-2 gap-3">
-            <div><p className="text-xs text-gray-500 uppercase tracking-wider mb-1">Amount</p>
-              <p className="text-white font-medium text-sm">{parseFloat(escrow.amount).toLocaleString()} {escrow.asset}</p></div>
-            <div><p className="text-xs text-gray-500 uppercase tracking-wider mb-1">Status</p><StatusBadge status={escrow.status} /></div>
-            <div><p className="text-xs text-gray-500 uppercase tracking-wider mb-1">Type</p><p className="text-white text-sm">{escrow.type}</p></div>
-            <div><p className="text-xs text-gray-500 uppercase tracking-wider mb-1">Created</p>
-              <p className="text-white text-sm">{new Date(escrow.createdAt).toLocaleDateString()}</p></div>
+            <div>
+              <p className="text-xs text-gray-500 uppercase tracking-wider mb-1">Amount</p>
+              <p className="text-white font-medium text-sm">
+                {parseFloat(escrow.amount).toLocaleString()} {escrow.asset}
+              </p>
+            </div>
+            <div>
+              <p className="text-xs text-gray-500 uppercase tracking-wider mb-1">Status</p>
+              <StatusBadge status={escrow.status} />
+            </div>
+            <div>
+              <p className="text-xs text-gray-500 uppercase tracking-wider mb-1">Type</p>
+              <p className="text-white text-sm">{escrow.type}</p>
+            </div>
+            <div>
+              <p className="text-xs text-gray-500 uppercase tracking-wider mb-1">Created</p>
+              <p className="text-white text-sm">{new Date(escrow.createdAt).toLocaleDateString()}</p>
+            </div>
           </div>
           <div>
             <p className="text-xs text-gray-500 uppercase tracking-wider mb-2">Parties</p>
@@ -79,7 +87,9 @@ function EscrowDetailModal({ escrow, onClose, onConsistencyCheck }: {
                     <p className="text-xs text-gray-300">{party.role}</p>
                     <p className="text-[10px] text-gray-500 font-mono">{party.userId}</p>
                   </div>
-                  <span className={`text-[10px] px-2 py-0.5 rounded-full ${party.status === 'ACCEPTED' ? 'bg-emerald-500/10 text-emerald-400' : 'bg-yellow-500/10 text-yellow-400'}`}>
+                  <span
+                    className={`text-[10px] px-2 py-0.5 rounded-full ${party.status === "ACCEPTED" ? "bg-emerald-500/10 text-emerald-400" : "bg-yellow-500/10 text-yellow-400"}`}
+                  >
                     {party.status}
                   </span>
                 </div>
@@ -106,13 +116,23 @@ function EscrowDetailModal({ escrow, onClose, onConsistencyCheck }: {
               Run Consistency Check
             </button>
             {result && (
-              <div className={`mt-3 p-3 rounded-lg text-xs ${result.issues.length === 0 ? 'bg-emerald-500/10 text-emerald-400' : 'bg-yellow-500/10 text-yellow-400'}`}>
+              <div className={`mt-3 p-3 rounded-lg text-xs ${result.issues.length === 0 ? "bg-emerald-500/10 text-emerald-400" : "bg-yellow-500/10 text-yellow-400"}`}>
                 {result.issues.length === 0 ? (
-                  <div className="flex items-center gap-2"><CheckCircle2 className="w-4 h-4" />No issues found.</div>
+                  <div className="flex items-center gap-2">
+                    <CheckCircle2 className="w-4 h-4" />
+                    No issues found.
+                  </div>
                 ) : (
                   <div>
-                    <div className="flex items-center gap-2 mb-2"><AlertCircle className="w-4 h-4" />Issues detected:</div>
-                    <ul className="list-disc list-inside space-y-1">{result.issues.map((issue, i) => <li key={i}>{issue}</li>)}</ul>
+                    <div className="flex items-center gap-2 mb-2">
+                      <AlertCircle className="w-4 h-4" />
+                      Issues detected:
+                    </div>
+                    <ul className="list-disc list-inside space-y-1">
+                      {result.issues.map((issue, i) => (
+                        <li key={i}>{issue}</li>
+                      ))}
+                    </ul>
                   </div>
                 )}
               </div>
@@ -137,8 +157,12 @@ function EscrowCard({ escrow, onView }: { escrow: IAdminEscrow; onView: () => vo
       </div>
       <div className="flex items-center justify-between">
         <div className="space-y-0.5">
-          <p className="text-sm text-white">{parseFloat(escrow.amount).toLocaleString()} <span className="text-gray-400 text-xs">{escrow.asset}</span></p>
-          <p className="text-xs text-gray-500">{escrow.type} · {new Date(escrow.createdAt).toLocaleDateString()}</p>
+          <p className="text-sm text-white">
+            {parseFloat(escrow.amount).toLocaleString()} <span className="text-gray-400 text-xs">{escrow.asset}</span>
+          </p>
+          <p className="text-xs text-gray-500">
+            {escrow.type} · {new Date(escrow.createdAt).toLocaleDateString()}
+          </p>
         </div>
         <button
           onClick={onView}
@@ -156,7 +180,7 @@ export default function AdminEscrowsPage() {
   const [data, setData] = useState<IAdminEscrowResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [page, setPage] = useState(1);
-  const [statusFilter, setStatusFilter] = useState('ALL');
+  const [statusFilter, setStatusFilter] = useState("ALL");
   const [selectedEscrow, setSelectedEscrow] = useState<IAdminEscrow | null>(null);
   const { success, error } = useToast();
 
@@ -165,19 +189,21 @@ export default function AdminEscrowsPage() {
   const [exportModalOpen, setExportModalOpen] = useState(false);
   const [exportFormat, setExportFormat] = useState<ExportFormat>("csv");
 
-  const statuses = ['ALL', 'ACTIVE', 'COMPLETED', 'PENDING', 'CANCELLED', 'DISPUTED'];
+  const statuses = ["ALL", "ACTIVE", "COMPLETED", "PENDING", "CANCELLED", "DISPUTED"];
 
   const fetchEscrows = useCallback(async () => {
     setLoading(true);
     try {
-      const result = await AdminService.getEscrows({ status: statusFilter === 'ALL' ? undefined : statusFilter, page, limit: 10 });
+      const result = await AdminService.getEscrows({ status: statusFilter === "ALL" ? undefined : statusFilter, page, limit: 10 });
       setData(result);
     } finally {
       setLoading(false);
     }
   }, [page, statusFilter]);
 
-  useEffect(() => { fetchEscrows(); }, [fetchEscrows]);
+  useEffect(() => {
+    fetchEscrows();
+  }, [fetchEscrows]);
 
   const handleExportClick = (format: ExportFormat) => {
     setExportFormat(format);
@@ -191,7 +217,7 @@ export default function AdminEscrowsPage() {
     try {
       // Fetch all escrows with the selected filters (no pagination for export)
       const result = await AdminService.getEscrows({
-        status: statusFilter === 'ALL' ? undefined : statusFilter,
+        status: statusFilter === "ALL" ? undefined : statusFilter,
         page: 1,
         limit: 10000,
       });
@@ -201,45 +227,47 @@ export default function AdminEscrowsPage() {
           if (exportFormat === "csv") {
             // Convert escrows to CSV format
             const headers = ["ID", "Title", "Amount", "Asset", "Status", "Type", "Created At"];
-            const rows = result.escrows.map(escrow => [
-            escrow.id,
-            escrow.title,
-            escrow.amount,
-            escrow.asset,
-            escrow.status,
-            escrow.type,
-            new Date(escrow.createdAt).toISOString(),
-          ]);
+            const rows = result.escrows.map((escrow) => [
+              escrow.id,
+              escrow.title,
+              escrow.amount,
+              escrow.asset,
+              escrow.status,
+              escrow.type,
+              new Date(escrow.createdAt).toISOString(),
+            ]);
 
-          const csvContent = [
-            headers.join(","),
-            ...rows.map(row =>
-              row.map(cell => {
-                const cellStr = String(cell);
-                if (cellStr.includes(",") || cellStr.includes('"') || cellStr.includes("\n")) {
-                  return `"${cellStr.replace(/"/g, '""')}"`;
-                }
-                return cellStr;
-              }).join(",")
-            )
-          ].join("\n");
+            const csvContent = [
+              headers.join(","),
+              ...rows.map((row) =>
+                row
+                  .map((cell) => {
+                    const cellStr = String(cell);
+                    if (cellStr.includes(",") || cellStr.includes('"') || cellStr.includes("\n")) {
+                      return `"${cellStr.replace(/"/g, '""')}"`;
+                    }
+                    return cellStr;
+                  })
+                  .join(","),
+              ),
+            ].join("\n");
 
-          const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
-          const link = document.createElement("a");
-          const url = URL.createObjectURL(blob);
-          link.setAttribute("href", url);
-          link.setAttribute("download", `vaultix-escrows-${new Date().toISOString().split("T")[0]}.csv`);
-          link.style.visibility = "hidden";
-          document.body.appendChild(link);
-          link.click();
-          document.body.removeChild(link);
-          URL.revokeObjectURL(url);
+            const blob = new Blob([csvContent], { type: "text/csv;charset=utf-8;" });
+            const link = document.createElement("a");
+            const url = URL.createObjectURL(blob);
+            link.setAttribute("href", url);
+            link.setAttribute("download", `vaultix-escrows-${new Date().toISOString().split("T")[0]}.csv`);
+            link.style.visibility = "hidden";
+            document.body.appendChild(link);
+            link.click();
+            document.body.removeChild(link);
+            URL.revokeObjectURL(url);
 
-          success(`Successfully exported ${result.escrows.length} escrows to CSV`);
-        } else {
-          // PDF export would require jsPDF - for now show a message
-          error("PDF export for escrows is not yet implemented");
-        }
+            success(`Successfully exported ${result.escrows.length} escrows to CSV`);
+          } else {
+            // PDF export would require jsPDF - for now show a message
+            error("PDF export for escrows is not yet implemented");
+          }
         } catch (err) {
           error("Failed to generate export file");
           console.error("Export error:", err);
@@ -261,11 +289,7 @@ export default function AdminEscrowsPage() {
           <h1 className="text-xl sm:text-2xl font-bold text-white">Escrow Management</h1>
           <p className="text-sm text-gray-500 mt-1">Monitor and manage all platform escrows</p>
         </div>
-        <ExportDropdown
-          onExport={handleExportClick}
-          disabled={!data || data.escrows.length === 0}
-          isLoading={isExporting}
-        />
+        <ExportDropdown onExport={handleExportClick} disabled={!data || data.escrows.length === 0} isLoading={isExporting} />
       </div>
 
       {/* Filters — scrollable on mobile */}
@@ -275,11 +299,14 @@ export default function AdminEscrowsPage() {
           {statuses.map((s) => (
             <button
               key={s}
-              onClick={() => { setStatusFilter(s); setPage(1); }}
+              onClick={() => {
+                setStatusFilter(s);
+                setPage(1);
+              }}
               className={`min-h-[44px] px-3 py-1.5 rounded-lg text-xs font-medium transition-all whitespace-nowrap ${
                 statusFilter === s
-                  ? 'bg-purple-600/20 text-purple-300 border border-purple-500/30'
-                  : 'bg-white/[0.03] text-gray-400 border border-white/5 hover:border-white/10'
+                  ? "bg-purple-600/20 text-purple-300 border border-purple-500/30"
+                  : "bg-white/[0.03] text-gray-400 border border-white/5 hover:border-white/10"
               }`}
             >
               {s}
@@ -289,9 +316,7 @@ export default function AdminEscrowsPage() {
       </div>
 
       {loading ? (
-        <div className="flex items-center justify-center py-20">
-          <Loader2 className="w-6 h-6 text-purple-500 animate-spin" />
-        </div>
+        <AdminTableSkeleton rows={8} />
       ) : (
         <>
           {/* Mobile card list */}
@@ -307,8 +332,10 @@ export default function AdminEscrowsPage() {
               <table className="w-full">
                 <thead>
                   <tr className="border-b border-white/5">
-                    {['Title', 'Amount', 'Status', 'Type', 'Created', 'Actions'].map((h, i) => (
-                      <th key={h} className={`text-[11px] text-gray-500 uppercase tracking-wider font-medium px-5 py-3 ${i === 5 ? 'text-right' : 'text-left'}`}>{h}</th>
+                    {["Title", "Amount", "Status", "Type", "Created", "Actions"].map((h, i) => (
+                      <th key={h} className={`text-[11px] text-gray-500 uppercase tracking-wider font-medium px-5 py-3 ${i === 5 ? "text-right" : "text-left"}`}>
+                        {h}
+                      </th>
                     ))}
                   </tr>
                 </thead>
@@ -319,14 +346,27 @@ export default function AdminEscrowsPage() {
                         <p className="text-sm text-white font-medium">{escrow.title}</p>
                         <p className="text-[10px] text-gray-600 font-mono mt-0.5">{escrow.id}</p>
                       </td>
-                      <td className="px-5 py-3.5"><p className="text-sm text-white">{parseFloat(escrow.amount).toLocaleString()} {escrow.asset}</p></td>
-                      <td className="px-5 py-3.5"><StatusBadge status={escrow.status} /></td>
-                      <td className="px-5 py-3.5"><span className="text-xs text-gray-400">{escrow.type}</span></td>
-                      <td className="px-5 py-3.5"><span className="text-xs text-gray-400">{new Date(escrow.createdAt).toLocaleDateString()}</span></td>
+                      <td className="px-5 py-3.5">
+                        <p className="text-sm text-white">
+                          {parseFloat(escrow.amount).toLocaleString()} {escrow.asset}
+                        </p>
+                      </td>
+                      <td className="px-5 py-3.5">
+                        <StatusBadge status={escrow.status} />
+                      </td>
+                      <td className="px-5 py-3.5">
+                        <span className="text-xs text-gray-400">{escrow.type}</span>
+                      </td>
+                      <td className="px-5 py-3.5">
+                        <span className="text-xs text-gray-400">{new Date(escrow.createdAt).toLocaleDateString()}</span>
+                      </td>
                       <td className="px-5 py-3.5 text-right">
-                        <button onClick={() => setSelectedEscrow(escrow)}
-                          className="min-h-[44px] inline-flex items-center gap-1.5 text-xs text-purple-400 hover:text-purple-300 transition-colors px-2">
-                          <Eye className="w-3.5 h-3.5" />View
+                        <button
+                          onClick={() => setSelectedEscrow(escrow)}
+                          className="min-h-[44px] inline-flex items-center gap-1.5 text-xs text-purple-400 hover:text-purple-300 transition-colors px-2"
+                        >
+                          <Eye className="w-3.5 h-3.5" />
+                          View
                         </button>
                       </td>
                     </tr>
@@ -336,14 +376,22 @@ export default function AdminEscrowsPage() {
             </div>
             {data && data.pagination.pages > 1 && (
               <div className="flex items-center justify-between px-5 py-3 border-t border-white/5">
-                <p className="text-xs text-gray-500">Page {data.pagination.page} of {data.pagination.pages} ({data.pagination.total} escrows)</p>
+                <p className="text-xs text-gray-500">
+                  Page {data.pagination.page} of {data.pagination.pages} ({data.pagination.total} escrows)
+                </p>
                 <div className="flex items-center gap-2">
-                  <button onClick={() => setPage(p => Math.max(1, p - 1))} disabled={page === 1}
-                    className="min-w-[44px] min-h-[44px] flex items-center justify-center rounded-lg bg-white/5 text-gray-400 hover:text-white disabled:opacity-30">
+                  <button
+                    onClick={() => setPage((p) => Math.max(1, p - 1))}
+                    disabled={page === 1}
+                    className="min-w-[44px] min-h-[44px] flex items-center justify-center rounded-lg bg-white/5 text-gray-400 hover:text-white disabled:opacity-30"
+                  >
                     <ChevronLeft className="w-4 h-4" />
                   </button>
-                  <button onClick={() => setPage(p => Math.min(data.pagination.pages, p + 1))} disabled={page === data.pagination.pages}
-                    className="min-w-[44px] min-h-[44px] flex items-center justify-center rounded-lg bg-white/5 text-gray-400 hover:text-white disabled:opacity-30">
+                  <button
+                    onClick={() => setPage((p) => Math.min(data.pagination.pages, p + 1))}
+                    disabled={page === data.pagination.pages}
+                    className="min-w-[44px] min-h-[44px] flex items-center justify-center rounded-lg bg-white/5 text-gray-400 hover:text-white disabled:opacity-30"
+                  >
                     <ChevronRight className="w-4 h-4" />
                   </button>
                 </div>
@@ -354,14 +402,22 @@ export default function AdminEscrowsPage() {
           {/* Mobile pagination */}
           {data && data.pagination.pages > 1 && (
             <div className="sm:hidden flex items-center justify-between">
-              <p className="text-xs text-gray-500">Page {data.pagination.page} of {data.pagination.pages}</p>
+              <p className="text-xs text-gray-500">
+                Page {data.pagination.page} of {data.pagination.pages}
+              </p>
               <div className="flex gap-2">
-                <button onClick={() => setPage(p => Math.max(1, p - 1))} disabled={page === 1}
-                  className="min-w-[44px] min-h-[44px] flex items-center justify-center rounded-lg bg-white/5 text-gray-400 hover:text-white disabled:opacity-30">
+                <button
+                  onClick={() => setPage((p) => Math.max(1, p - 1))}
+                  disabled={page === 1}
+                  className="min-w-[44px] min-h-[44px] flex items-center justify-center rounded-lg bg-white/5 text-gray-400 hover:text-white disabled:opacity-30"
+                >
                   <ChevronLeft className="w-4 h-4" />
                 </button>
-                <button onClick={() => setPage(p => Math.min(data.pagination.pages, p + 1))} disabled={page === data.pagination.pages}
-                  className="min-w-[44px] min-h-[44px] flex items-center justify-center rounded-lg bg-white/5 text-gray-400 hover:text-white disabled:opacity-30">
+                <button
+                  onClick={() => setPage((p) => Math.min(data.pagination.pages, p + 1))}
+                  disabled={page === data.pagination.pages}
+                  className="min-w-[44px] min-h-[44px] flex items-center justify-center rounded-lg bg-white/5 text-gray-400 hover:text-white disabled:opacity-30"
+                >
                   <ChevronRight className="w-4 h-4" />
                 </button>
               </div>
@@ -371,20 +427,11 @@ export default function AdminEscrowsPage() {
       )}
 
       {selectedEscrow && (
-        <EscrowDetailModal
-          escrow={selectedEscrow}
-          onClose={() => setSelectedEscrow(null)}
-          onConsistencyCheck={(id) => console.log('consistency check', id)}
-        />
+        <EscrowDetailModal escrow={selectedEscrow} onClose={() => setSelectedEscrow(null)} onConsistencyCheck={(id) => console.log("consistency check", id)} />
       )}
 
       {/* Export Modal */}
-      <ExportModal
-        isOpen={exportModalOpen}
-        onClose={() => setExportModalOpen(false)}
-        onConfirm={handleExportConfirm}
-        isLoading={isExporting}
-      />
+      <ExportModal isOpen={exportModalOpen} onClose={() => setExportModalOpen(false)} onConfirm={handleExportConfirm} isLoading={isExporting} />
     </div>
   );
 }

--- a/apps/frontend/app/admin/page.tsx
+++ b/apps/frontend/app/admin/page.tsx
@@ -1,21 +1,10 @@
-'use client';
+"use client";
 
-import React, { useState, useEffect } from 'react';
-import {
-  Users,
-  Shield,
-  TrendingUp,
-  Activity,
-  ArrowUpRight,
-  ArrowDownRight,
-  BarChart3,
-  Wallet,
-  UserPlus,
-  CheckCircle2,
-  Loader2,
-} from 'lucide-react';
-import { AdminService } from '@/services/admin';
-import { IPlatformStats } from '@/types/admin';
+import React, { useState, useEffect } from "react";
+import { Users, Shield, TrendingUp, Activity, ArrowUpRight, ArrowDownRight, BarChart3, Wallet, UserPlus, CheckCircle2 } from "lucide-react";
+import { AdminService } from "@/services/admin";
+import { IPlatformStats } from "@/types/admin";
+import { AdminOverviewSkeleton } from "@/components/ui/AdminOverviewSkeleton";
 
 function StatCard({
   title,
@@ -35,41 +24,29 @@ function StatCard({
   const isPositive = change && change > 0;
   return (
     <div className="relative group">
-      <div className="absolute -inset-[1px] bg-gradient-to-r opacity-0 group-hover:opacity-100 rounded-xl transition-opacity duration-500 blur-sm"
+      <div
+        className="absolute -inset-[1px] bg-gradient-to-r opacity-0 group-hover:opacity-100 rounded-xl transition-opacity duration-500 blur-sm"
         style={{ backgroundImage: gradient }}
       />
       <div className="relative bg-[#12121a] border border-white/5 rounded-xl p-5 hover:border-white/10 transition-all duration-300">
         <div className="flex items-start justify-between mb-4">
-          <div
-            className="w-10 h-10 rounded-lg flex items-center justify-center"
-            style={{ background: gradient }}
-          >
+          <div className="w-10 h-10 rounded-lg flex items-center justify-center" style={{ background: gradient }}>
             <Icon className="w-5 h-5 text-white" />
           </div>
           {change !== undefined && (
             <div
               className={`flex items-center gap-1 text-xs font-medium px-2 py-1 rounded-full ${
-                isPositive
-                  ? 'bg-emerald-500/10 text-emerald-400'
-                  : 'bg-red-500/10 text-red-400'
+                isPositive ? "bg-emerald-500/10 text-emerald-400" : "bg-red-500/10 text-red-400"
               }`}
             >
-              {isPositive ? (
-                <ArrowUpRight className="w-3 h-3" />
-              ) : (
-                <ArrowDownRight className="w-3 h-3" />
-              )}
+              {isPositive ? <ArrowUpRight className="w-3 h-3" /> : <ArrowDownRight className="w-3 h-3" />}
               {Math.abs(change)}%
             </div>
           )}
         </div>
-        <p className="text-2xl font-bold text-white mb-1">
-          {typeof value === 'number' ? value.toLocaleString() : value}
-        </p>
+        <p className="text-2xl font-bold text-white mb-1">{typeof value === "number" ? value.toLocaleString() : value}</p>
         <p className="text-xs text-gray-500">{title}</p>
-        {changeLabel && (
-          <p className="text-[10px] text-gray-600 mt-1">{changeLabel}</p>
-        )}
+        {changeLabel && <p className="text-[10px] text-gray-600 mt-1">{changeLabel}</p>}
       </div>
     </div>
   );
@@ -78,9 +55,9 @@ function StatCard({
 function RoleDistribution({ roles }: { roles: Record<string, number> }) {
   const total = Object.values(roles).reduce((a, b) => a + b, 0);
   const colors: Record<string, string> = {
-    USER: '#8b5cf6',
-    ADMIN: '#3b82f6',
-    SUPER_ADMIN: '#06b6d4',
+    USER: "#8b5cf6",
+    ADMIN: "#3b82f6",
+    SUPER_ADMIN: "#06b6d4",
   };
 
   return (
@@ -95,9 +72,7 @@ function RoleDistribution({ roles }: { roles: Record<string, number> }) {
           return (
             <div key={role}>
               <div className="flex items-center justify-between mb-1.5">
-                <span className="text-xs text-gray-400 capitalize">
-                  {role.replace('_', ' ').toLowerCase()}
-                </span>
+                <span className="text-xs text-gray-400 capitalize">{role.replace("_", " ").toLowerCase()}</span>
                 <span className="text-xs text-gray-300 font-medium">
                   {count.toLocaleString()} ({pct.toFixed(1)}%)
                 </span>
@@ -107,7 +82,7 @@ function RoleDistribution({ roles }: { roles: Record<string, number> }) {
                   className="h-full rounded-full transition-all duration-1000 ease-out"
                   style={{
                     width: `${pct}%`,
-                    backgroundColor: colors[role] || '#8b5cf6',
+                    backgroundColor: colors[role] || "#8b5cf6",
                   }}
                 />
               </div>
@@ -121,7 +96,7 @@ function RoleDistribution({ roles }: { roles: Record<string, number> }) {
 
 function EscrowVolumeChart() {
   // Simulated chart data
-  const months = ['Oct', 'Nov', 'Dec', 'Jan', 'Feb', 'Mar'];
+  const months = ["Oct", "Nov", "Dec", "Jan", "Feb", "Mar"];
   const values = [320, 480, 560, 720, 610, 850];
   const max = Math.max(...values);
 
@@ -137,9 +112,7 @@ function EscrowVolumeChart() {
           const height = (values[i] / max) * 100;
           return (
             <div key={month} className="flex-1 flex flex-col items-center gap-2">
-              <span className="text-[10px] text-gray-500 font-medium">
-                {values[i]}
-              </span>
+              <span className="text-[10px] text-gray-500 font-medium">{values[i]}</span>
               <div className="w-full relative rounded-t-md overflow-hidden" style={{ height: `${height}%` }}>
                 <div
                   className="absolute inset-0 rounded-t-md transition-all duration-700 ease-out"
@@ -159,11 +132,11 @@ function EscrowVolumeChart() {
 
 function RecentActivity() {
   const activities = [
-    { type: 'escrow_created', desc: 'New escrow created: "Website Dev"', time: '5m ago', icon: Shield },
-    { type: 'user_joined', desc: 'New user registered: GAX3...', time: '12m ago', icon: UserPlus },
-    { type: 'escrow_completed', desc: 'Escrow completed: "API Integration"', time: '28m ago', icon: CheckCircle2 },
-    { type: 'user_joined', desc: 'New user registered: GBK2...', time: '1h ago', icon: UserPlus },
-    { type: 'escrow_created', desc: 'New escrow created: "DeFi Audit"', time: '2h ago', icon: Shield },
+    { type: "escrow_created", desc: 'New escrow created: "Website Dev"', time: "5m ago", icon: Shield },
+    { type: "user_joined", desc: "New user registered: GAX3...", time: "12m ago", icon: UserPlus },
+    { type: "escrow_completed", desc: 'Escrow completed: "API Integration"', time: "28m ago", icon: CheckCircle2 },
+    { type: "user_joined", desc: "New user registered: GBK2...", time: "1h ago", icon: UserPlus },
+    { type: "escrow_created", desc: 'New escrow created: "DeFi Audit"', time: "2h ago", icon: Shield },
   ];
 
   return (
@@ -203,14 +176,7 @@ export default function AdminOverviewPage() {
   }, []);
 
   if (loading) {
-    return (
-      <div className="flex items-center justify-center min-h-[60vh]">
-        <div className="flex flex-col items-center gap-3">
-          <Loader2 className="w-8 h-8 text-purple-500 animate-spin" />
-          <p className="text-sm text-gray-500">Loading dashboard...</p>
-        </div>
-      </div>
-    );
+    return <AdminOverviewSkeleton />;
   }
 
   if (!stats) return null;
@@ -220,9 +186,7 @@ export default function AdminOverviewPage() {
       {/* Page header */}
       <div>
         <h1 className="text-2xl font-bold text-white">Platform Overview</h1>
-        <p className="text-sm text-gray-500 mt-1">
-          Real-time platform statistics and monitoring
-        </p>
+        <p className="text-sm text-gray-500 mt-1">Real-time platform statistics and monitoring</p>
       </div>
 
       {/* Stats grid */}
@@ -278,34 +242,19 @@ export default function AdminOverviewPage() {
           </h3>
           <div className="grid grid-cols-2 gap-4">
             <div className="bg-white/[0.02] rounded-lg p-4">
-              <p className="text-2xl font-bold text-white">
-                {stats.users.active.toLocaleString()}
-              </p>
+              <p className="text-2xl font-bold text-white">{stats.users.active.toLocaleString()}</p>
               <p className="text-xs text-gray-500 mt-1">Active Users</p>
             </div>
             <div className="bg-white/[0.02] rounded-lg p-4">
-              <p className="text-2xl font-bold text-white">
-                {stats.escrows.total.toLocaleString()}
-              </p>
+              <p className="text-2xl font-bold text-white">{stats.escrows.total.toLocaleString()}</p>
               <p className="text-xs text-gray-500 mt-1">Total Escrows</p>
             </div>
             <div className="bg-white/[0.02] rounded-lg p-4">
-              <p className="text-2xl font-bold text-white">
-                {(
-                  (stats.escrows.completed / Math.max(stats.escrows.total, 1)) *
-                  100
-                ).toFixed(1)}
-                %
-              </p>
+              <p className="text-2xl font-bold text-white">{((stats.escrows.completed / Math.max(stats.escrows.total, 1)) * 100).toFixed(1)}%</p>
               <p className="text-xs text-gray-500 mt-1">Completion Rate</p>
             </div>
             <div className="bg-white/[0.02] rounded-lg p-4">
-              <p className="text-2xl font-bold text-white">
-                {Math.round(
-                  stats.volume.totalCompleted /
-                    Math.max(stats.escrows.completed, 1)
-                ).toLocaleString()}
-              </p>
+              <p className="text-2xl font-bold text-white">{Math.round(stats.volume.totalCompleted / Math.max(stats.escrows.completed, 1)).toLocaleString()}</p>
               <p className="text-xs text-gray-500 mt-1">Avg Volume (XLM)</p>
             </div>
           </div>

--- a/apps/frontend/app/dashboard/page.tsx
+++ b/apps/frontend/app/dashboard/page.tsx
@@ -1,19 +1,21 @@
 "use client";
 
 import { Suspense, useCallback, useState } from "react";
-import { QueryErrorResetBoundary } from '@tanstack/react-query';
+import { QueryErrorResetBoundary } from "@tanstack/react-query";
 import { useSearchParams, useRouter, usePathname } from "next/navigation";
 import StatusTabs from "@/components/dashboard/StatusTabs";
 import EscrowList from "@/components/dashboard/EscrowList";
 import EscrowFilters from "@/components/dashboard/EscrowFilters";
 import FilterBadges from "@/components/dashboard/FilterBadges";
-import { ErrorBoundary } from '@/components/ErrorBoundary';
-import { ErrorFallback } from '@/components/ErrorFallback';
+import { ErrorBoundary } from "@/components/ErrorBoundary";
+import { ErrorFallback } from "@/components/ErrorFallback";
 import { useEscrows } from "../../hooks/useEscrows";
 import ActivityFeed from "@/components/common/ActivityFeed";
 import Link from "next/link";
 import { PlusCircle, Activity, X } from "lucide-react";
 import { useEscrowWebSocket } from "@/hooks/useEscrowWebSocket";
+import { EscrowCardSkeleton } from "@/components/ui/EscrowCardSkeleton";
+import { ActivityFeedSkeleton } from "@/components/ui/ActivityFeedSkeleton";
 
 function DashboardContent() {
   const searchParams = useSearchParams();
@@ -23,11 +25,9 @@ function DashboardContent() {
 
   useEscrowWebSocket();
 
-  const activeStatuses =
-    searchParams.get("status")?.split(",").filter(Boolean) || [];
+  const activeStatuses = searchParams.get("status")?.split(",").filter(Boolean) || [];
   const searchQuery = searchParams.get("search") || "";
-  const sortBy =
-    (searchParams.get("sort") as "date" | "amount" | "deadline") || "date";
+  const sortBy = (searchParams.get("sort") as "date" | "amount" | "deadline") || "date";
   const sortOrder = (searchParams.get("order") as "asc" | "desc") || "desc";
   const minAmount = searchParams.get("minAmount") || "";
   const maxAmount = searchParams.get("maxAmount") || "";
@@ -35,14 +35,7 @@ function DashboardContent() {
   const toDate = searchParams.get("toDate") || "";
   const walletAddress = searchParams.get("walletAddress") || "";
 
-  const hasActiveFilters =
-    activeStatuses.length > 0 ||
-    searchQuery ||
-    minAmount ||
-    maxAmount ||
-    fromDate ||
-    toDate ||
-    walletAddress;
+  const hasActiveFilters = activeStatuses.length > 0 || searchQuery || minAmount || maxAmount || fromDate || toDate || walletAddress;
 
   const createQueryString = useCallback(
     (paramsToUpdate: Record<string, string | null>) => {
@@ -61,37 +54,17 @@ function DashboardContent() {
     if (status === "all") {
       nextStatuses = [];
     } else {
-      nextStatuses = activeStatuses.includes(status)
-        ? activeStatuses.filter((s) => s !== status)
-        : [...activeStatuses, status];
+      nextStatuses = activeStatuses.includes(status) ? activeStatuses.filter((s) => s !== status) : [...activeStatuses, status];
     }
-    router.push(
-      `${pathname}?${createQueryString({ status: nextStatuses.length ? nextStatuses.join(",") : null })}`,
-    );
+    router.push(`${pathname}?${createQueryString({ status: nextStatuses.length ? nextStatuses.join(",") : null })}`);
   };
 
-  const handleSearch = (query: string) =>
-    router.push(`${pathname}?${createQueryString({ search: query })}`);
-  const handleSortChange = (
-    field: "date" | "amount" | "deadline",
-    order: "asc" | "desc",
-  ) => router.push(`${pathname}?${createQueryString({ sort: field, order })}`);
-  const handleAmountChange = (min: string, max: string) =>
-    router.push(
-      `${pathname}?${createQueryString({ minAmount: min, maxAmount: max })}`,
-    );
-  const handleDateChange = (from: string, to: string) =>
-    router.push(
-      `${pathname}?${createQueryString({ fromDate: from, toDate: to })}`,
-    );
-  const handleWalletAddressChange = (address: string) =>
-    router.push(
-      `${pathname}?${createQueryString({ walletAddress: address })}`,
-    );
-  const handleClearFilter = (key: string) =>
-    router.push(
-      `${pathname}?${createQueryString({ [key]: null })}`,
-    );
+  const handleSearch = (query: string) => router.push(`${pathname}?${createQueryString({ search: query })}`);
+  const handleSortChange = (field: "date" | "amount" | "deadline", order: "asc" | "desc") => router.push(`${pathname}?${createQueryString({ sort: field, order })}`);
+  const handleAmountChange = (min: string, max: string) => router.push(`${pathname}?${createQueryString({ minAmount: min, maxAmount: max })}`);
+  const handleDateChange = (from: string, to: string) => router.push(`${pathname}?${createQueryString({ fromDate: from, toDate: to })}`);
+  const handleWalletAddressChange = (address: string) => router.push(`${pathname}?${createQueryString({ walletAddress: address })}`);
+  const handleClearFilter = (key: string) => router.push(`${pathname}?${createQueryString({ [key]: null })}`);
 
   const {
     data: escrowsData,
@@ -114,34 +87,20 @@ function DashboardContent() {
     walletAddress,
   });
 
-  const flatEscrows =
-    escrowsData?.pages.flatMap((page: any) => page.escrows) || [];
+  const flatEscrows = escrowsData?.pages.flatMap((page: any) => page.escrows) || [];
 
-  const validStatuses = [
-    "all",
-    "active",
-    "pending",
-    "completed",
-    "disputed",
-  ] as const;
+  const validStatuses = ["all", "active", "pending", "completed", "disputed"] as const;
   type ValidStatus = (typeof validStatuses)[number];
 
   const firstStatus = activeStatuses[0];
-  const activeTab: ValidStatus = validStatuses.includes(
-    firstStatus as ValidStatus,
-  )
-    ? (firstStatus as ValidStatus)
-    : "all";
+  const activeTab: ValidStatus = validStatuses.includes(firstStatus as ValidStatus) ? (firstStatus as ValidStatus) : "all";
 
   return (
     <>
       {/* Mobile Activity Drawer */}
       {showActivity && (
         <div className="fixed inset-0 z-50 lg:hidden">
-          <div
-            className="absolute inset-0 bg-black/50 backdrop-blur-sm"
-            onClick={() => setShowActivity(false)}
-          />
+          <div className="absolute inset-0 bg-black/50 backdrop-blur-sm" onClick={() => setShowActivity(false)} />
           <div className="absolute right-0 top-0 h-full w-full max-w-sm bg-card text-card-foreground shadow-2xl flex flex-col">
             <div className="flex items-center justify-between p-4 border-b border-border">
               <h2 className="font-semibold text-foreground">Activity Feed</h2>
@@ -154,16 +113,7 @@ function DashboardContent() {
               </button>
             </div>
             <div className="flex-1 overflow-y-auto p-4">
-              <ErrorBoundary
-                fallback={({ error, reset }) => (
-                  <ErrorFallback
-                    error={error}
-                    reset={reset}
-                    title="Failed to load activity"
-                    compact
-                  />
-                )}
-              >
+              <ErrorBoundary fallback={({ error, reset }) => <ErrorFallback error={error} reset={reset} title="Failed to load activity" compact />}>
                 <ActivityFeed />
               </ErrorBoundary>
             </div>
@@ -202,10 +152,7 @@ function DashboardContent() {
             </div>
           </div>
 
-          <StatusTabs
-            activeStatuses={activeStatuses}
-            onToggleStatus={handleToggleStatus}
-          />
+          <StatusTabs activeStatuses={activeStatuses} onToggleStatus={handleToggleStatus} />
           <FilterBadges
             searchQuery={searchQuery}
             minAmount={minAmount}
@@ -231,16 +178,7 @@ function DashboardContent() {
             toDate={toDate}
             onDateChange={handleDateChange}
           />
-          <ErrorBoundary
-            fallback={({ error, reset }) => (
-              <ErrorFallback
-                error={error}
-                reset={reset}
-                title="Failed to load escrows"
-                compact
-              />
-            )}
-          >
+          <ErrorBoundary fallback={({ error, reset }) => <ErrorFallback error={error} reset={reset} title="Failed to load escrows" compact />}>
             <EscrowList
               escrows={flatEscrows}
               isLoading={isLoading}
@@ -255,16 +193,7 @@ function DashboardContent() {
         </div>
 
         <div className="hidden lg:block lg:col-span-1">
-          <ErrorBoundary
-            fallback={({ error, reset }) => (
-              <ErrorFallback
-                error={error}
-                reset={reset}
-                title="Failed to load activity"
-                compact
-              />
-            )}
-          >
+          <ErrorBoundary fallback={({ error, reset }) => <ErrorFallback error={error} reset={reset} title="Failed to load activity" compact />}>
             <ActivityFeed className="h-[calc(100vh-12rem)] sticky top-8" />
           </ErrorBoundary>
         </div>
@@ -278,12 +207,8 @@ export default function DashboardPage() {
     <div className="min-h-screen bg-background text-foreground py-6 sm:py-12">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="text-center mb-6 sm:mb-10">
-          <h1 className="text-2xl sm:text-4xl font-extrabold text-foreground">
-            Escrow Dashboard
-          </h1>
-          <p className="mt-2 sm:mt-4 text-base sm:text-lg text-muted-foreground">
-            Manage all your escrow agreements in one place
-          </p>
+          <h1 className="text-2xl sm:text-4xl font-extrabold text-foreground">Escrow Dashboard</h1>
+          <p className="mt-2 sm:mt-4 text-base sm:text-lg text-muted-foreground">Manage all your escrow agreements in one place</p>
         </div>
         <QueryErrorResetBoundary>
           {({ reset }) => (
@@ -302,8 +227,15 @@ export default function DashboardPage() {
             >
               <Suspense
                 fallback={
-                  <div className="text-center py-20 text-muted-foreground">
-                    Loading Dashboard...
+                  <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+                    <div className="lg:col-span-2 bg-card text-card-foreground rounded-xl shadow-sm border border-border p-4 sm:p-6 space-y-4">
+                      {Array.from({ length: 3 }).map((_, i) => (
+                        <EscrowCardSkeleton key={i} />
+                      ))}
+                    </div>
+                    <div className="hidden lg:block lg:col-span-1">
+                      <ActivityFeedSkeleton />
+                    </div>
                   </div>
                 }
               >
@@ -316,4 +248,3 @@ export default function DashboardPage() {
     </div>
   );
 }
-

--- a/apps/frontend/app/notifications/page.tsx
+++ b/apps/frontend/app/notifications/page.tsx
@@ -1,66 +1,67 @@
-'use client';
+"use client";
 
-import React, { useState, useEffect } from 'react';
-import Link from 'next/link';
-import { Bell, CheckCheck, ArrowLeft, Trash2, ChevronLeft, ChevronRight } from 'lucide-react';
-import { useNotifications } from '@/hooks/useNotifications';
-import { formatDistanceToNow } from '@/utils/date';
-import { toast } from 'sonner';
+import React, { useState, useEffect } from "react";
+import Link from "next/link";
+import { Bell, CheckCheck, ArrowLeft, Trash2, ChevronLeft, ChevronRight } from "lucide-react";
+import { useNotifications } from "@/hooks/useNotifications";
+import { formatDistanceToNow } from "@/utils/date";
+import { toast } from "sonner";
+import { NotificationListSkeleton } from "@/components/ui/NotificationListSkeleton";
 
 const EVENT_ICONS: Record<string, string> = {
-  ESCROW_CREATED: '📝',
-  ESCROW_FUNDED: '💰',
-  MILESTONE_RELEASED: '🎯',
-  ESCROW_COMPLETED: '✅',
-  ESCROW_CANCELLED: '❌',
-  DISPUTE_RAISED: '⚠️',
-  DISPUTE_RESOLVED: '✓',
-  ESCROW_EXPIRED: '⏰',
-  CONDITION_FULFILLED: '✔️',
-  CONDITION_CONFIRMED: '👍',
-  EXPIRATION_WARNING: '⚡',
+  ESCROW_CREATED: "📝",
+  ESCROW_FUNDED: "💰",
+  MILESTONE_RELEASED: "🎯",
+  ESCROW_COMPLETED: "✅",
+  ESCROW_CANCELLED: "❌",
+  DISPUTE_RAISED: "⚠️",
+  DISPUTE_RESOLVED: "✓",
+  ESCROW_EXPIRED: "⏰",
+  CONDITION_FULFILLED: "✔️",
+  CONDITION_CONFIRMED: "👍",
+  EXPIRATION_WARNING: "⚡",
 };
 
 const EVENT_LABELS: Record<string, string> = {
-  ESCROW_CREATED: 'New escrow initialized',
-  ESCROW_FUNDED: 'Funds successfully deposited',
-  MILESTONE_RELEASED: 'Milestone funds released',
-  ESCROW_COMPLETED: 'Escrow completed successfully',
-  ESCROW_CANCELLED: 'Escrow contract cancelled',
-  DISPUTE_RAISED: 'Conflict dispute raised',
-  DISPUTE_RESOLVED: 'Conflict dispute resolved',
-  ESCROW_EXPIRED: 'Escrow contract expired',
-  CONDITION_FULFILLED: 'Condition fulfillment submitted',
-  CONDITION_CONFIRMED: 'Condition confirmed',
-  EXPIRATION_WARNING: 'Contract expiration warning',
+  ESCROW_CREATED: "New escrow initialized",
+  ESCROW_FUNDED: "Funds successfully deposited",
+  MILESTONE_RELEASED: "Milestone funds released",
+  ESCROW_COMPLETED: "Escrow completed successfully",
+  ESCROW_CANCELLED: "Escrow contract cancelled",
+  DISPUTE_RAISED: "Conflict dispute raised",
+  DISPUTE_RESOLVED: "Conflict dispute resolved",
+  ESCROW_EXPIRED: "Escrow contract expired",
+  CONDITION_FULFILLED: "Condition fulfillment submitted",
+  CONDITION_CONFIRMED: "Condition confirmed",
+  EXPIRATION_WARNING: "Contract expiration warning",
 };
 
 const FILTER_OPTIONS = [
-  { label: 'All notifications', value: 'ALL' },
-  { label: 'Unread', value: 'UNREAD' },
-  { label: 'Escrows', value: 'ESCROW' },
-  { label: 'Disputes', value: 'DISPUTE' },
+  { label: "All notifications", value: "ALL" },
+  { label: "Unread", value: "UNREAD" },
+  { label: "Escrows", value: "ESCROW" },
+  { label: "Disputes", value: "DISPUTE" },
 ];
 
 const PAGE_SIZE = 10;
 
 export default function NotificationsPage() {
   const { notifications, unreadCount, isLoading, markAsRead, markAllAsRead, refetch } = useNotifications();
-  const [filter, setFilter] = useState('ALL');
+  const [filter, setFilter] = useState("ALL");
   const [currentPage, setCurrentPage] = useState(1);
 
   // Apply filters
   const filtered = notifications.filter((n) => {
-    if (filter === 'UNREAD') return !n.readAt;
-    if (filter === 'ESCROW') return n.eventType.startsWith('ESCROW') || n.eventType.startsWith('CONDITION');
-    if (filter === 'DISPUTE') return n.eventType.startsWith('DISPUTE');
+    if (filter === "UNREAD") return !n.readAt;
+    if (filter === "ESCROW") return n.eventType.startsWith("ESCROW") || n.eventType.startsWith("CONDITION");
+    if (filter === "DISPUTE") return n.eventType.startsWith("DISPUTE");
     return true;
   });
 
   // Pagination calculations
   const totalItems = filtered.length;
   const totalPages = Math.ceil(totalItems / PAGE_SIZE) || 1;
-  
+
   useEffect(() => {
     // Reset to page 1 on filter change
     setCurrentPage(1);
@@ -75,20 +76,19 @@ export default function NotificationsPage() {
 
   const handleMarkAllAsRead = async () => {
     await markAllAsRead();
-    toast.success('All notifications marked as read');
+    toast.success("All notifications marked as read");
   };
 
   const handleDismiss = (id: string) => {
-    const currentDismissed = JSON.parse(localStorage.getItem('vaultix_dismissed_notifications') || '[]');
-    localStorage.setItem('vaultix_dismissed_notifications', JSON.stringify([...currentDismissed, id]));
+    const currentDismissed = JSON.parse(localStorage.getItem("vaultix_dismissed_notifications") || "[]");
+    localStorage.setItem("vaultix_dismissed_notifications", JSON.stringify([...currentDismissed, id]));
     refetch();
-    toast.success('Notification dismissed');
+    toast.success("Notification dismissed");
   };
 
   return (
     <div className="min-h-screen bg-[#0a0a0f] py-10 px-4 md:px-6">
       <div className="max-w-3xl mx-auto space-y-6">
-        
         {/* Navigation & Header */}
         <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4 border-b border-white/5 pb-5">
           <div className="flex items-center gap-3.5">
@@ -131,8 +131,8 @@ export default function NotificationsPage() {
               onClick={() => setFilter(f.value)}
               className={`px-4 py-2 rounded-full text-xs font-semibold whitespace-nowrap transition-colors cursor-pointer ${
                 filter === f.value
-                  ? 'bg-gradient-to-r from-purple-600 to-blue-500 text-white shadow-lg shadow-purple-500/15'
-                  : 'bg-[#12121a] border border-white/5 text-gray-400 hover:text-white'
+                  ? "bg-gradient-to-r from-purple-600 to-blue-500 text-white shadow-lg shadow-purple-500/15"
+                  : "bg-[#12121a] border border-white/5 text-gray-400 hover:text-white"
               }`}
             >
               {f.label}
@@ -143,10 +143,7 @@ export default function NotificationsPage() {
         {/* Notifications List Container */}
         <div className="bg-[#12121a] border border-white/5 rounded-xl overflow-hidden shadow-xl">
           {isLoading ? (
-            <div className="p-12 text-center text-gray-500">
-              <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-purple-500 mx-auto mb-3" />
-              <p className="text-xs">Fetching event feed...</p>
-            </div>
+            <NotificationListSkeleton />
           ) : paginated.length === 0 ? (
             /* Empty State Illustration */
             <div className="p-12 text-center space-y-4">
@@ -156,9 +153,9 @@ export default function NotificationsPage() {
               <div>
                 <h3 className="text-sm font-semibold text-white">No notifications</h3>
                 <p className="text-xs text-gray-500 mt-1 max-w-sm mx-auto">
-                  {filter === 'UNREAD'
-                    ? 'All caught up! You have read all notifications in this category.'
-                    : 'Nothing to see here. We will notify you when new escrow actions occur.'}
+                  {filter === "UNREAD"
+                    ? "All caught up! You have read all notifications in this category."
+                    : "Nothing to see here. We will notify you when new escrow actions occur."}
                 </p>
               </div>
             </div>
@@ -168,44 +165,32 @@ export default function NotificationsPage() {
                 <div
                   key={notification.id}
                   className={`group relative flex items-start justify-between gap-4 p-5 hover:bg-white/[0.01] transition-all duration-200 ${
-                    !notification.readAt ? 'bg-purple-950/5' : ''
+                    !notification.readAt ? "bg-purple-950/5" : ""
                   }`}
                 >
                   <Link
-                    href={notification.escrowId ? `/escrow/${notification.escrowId}` : '/dashboard'}
+                    href={notification.escrowId ? `/escrow/${notification.escrowId}` : "/dashboard"}
                     onClick={() => {
                       if (!notification.readAt) handleMarkAsRead(notification.id);
                     }}
                     className="flex-1 flex gap-4 min-w-0"
                   >
-                    <span className="text-2xl flex-shrink-0 mt-0.5 select-none">
-                      {EVENT_ICONS[notification.eventType] ?? '🔔'}
-                    </span>
+                    <span className="text-2xl flex-shrink-0 mt-0.5 select-none">{EVENT_ICONS[notification.eventType] ?? "🔔"}</span>
                     <div className="flex-1 min-w-0">
                       <div className="flex items-center gap-2">
-                        <p className="text-xs font-semibold text-white">
-                          {EVENT_LABELS[notification.eventType] ?? notification.eventType.replace(/_/g, ' ')}
-                        </p>
-                        {!notification.readAt && (
-                          <span className="w-1.5 h-1.5 bg-purple-500 rounded-full flex-shrink-0" />
-                        )}
+                        <p className="text-xs font-semibold text-white">{EVENT_LABELS[notification.eventType] ?? notification.eventType.replace(/_/g, " ")}</p>
+                        {!notification.readAt && <span className="w-1.5 h-1.5 bg-purple-500 rounded-full flex-shrink-0" />}
                       </div>
-                      
-                      {!!notification.payload?.message && (
-                        <p className="text-xs text-gray-400 mt-1 leading-relaxed">
-                          {String(notification.payload.message)}
-                        </p>
-                      )}
+
+                      {!!notification.payload?.message && <p className="text-xs text-gray-400 mt-1 leading-relaxed">{String(notification.payload.message)}</p>}
 
                       {notification.escrowId && (
                         <p className="text-[10px] text-gray-500 mt-1.5">
                           Escrow ID: <span className="font-mono">{notification.escrowId.slice(0, 12)}...</span>
                         </p>
                       )}
-                      
-                      <p className="text-[10px] text-gray-600 mt-2">
-                        {formatDistanceToNow(new Date(notification.createdAt))}
-                      </p>
+
+                      <p className="text-[10px] text-gray-600 mt-2">{formatDistanceToNow(new Date(notification.createdAt))}</p>
                     </div>
                   </Link>
 

--- a/apps/frontend/app/transactions/page.tsx
+++ b/apps/frontend/app/transactions/page.tsx
@@ -1,23 +1,9 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
-import {
-  Download,
-  Filter,
-  Calendar,
-  ExternalLink,
-  Loader2,
-  TrendingUp,
-  TrendingDown,
-  Wallet,
-  ArrowUpDown,
-} from "lucide-react";
+import { Download, Filter, Calendar, ExternalLink, Loader2, TrendingUp, TrendingDown, Wallet, ArrowUpDown } from "lucide-react";
 import { fetchEvents, IEventResponse } from "@/lib/escrow-api";
-import {
-  convertEventsToCSV,
-  downloadCSV,
-  generateTransactionFilename,
-} from "@/lib/csv-export";
+import { convertEventsToCSV, downloadCSV, generateTransactionFilename } from "@/lib/csv-export";
 import { convertEventsToPDF, downloadPDF } from "@/lib/pdf-export";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -25,6 +11,7 @@ import { Badge } from "@/components/ui/badge";
 import { ExportDropdown, ExportFormat } from "@/components/ExportDropdown";
 import { ExportModal } from "@/components/ExportModal";
 import { useToast } from "@/hooks/useToast";
+import { TransactionTableSkeleton } from "@/components/ui/TransactionTableSkeleton";
 
 const EVENT_TYPES = [
   { value: "", label: "All Events" },
@@ -207,12 +194,8 @@ export default function TransactionsPage() {
       <div className="max-w-7xl mx-auto">
         {/* Header */}
         <div className="mb-8">
-          <h1 className="text-3xl font-bold text-foreground mb-2">
-            Transaction History
-          </h1>
-          <p className="text-muted-foreground">
-            View and export all your escrow-related transactions
-          </p>
+          <h1 className="text-3xl font-bold text-foreground mb-2">Transaction History</h1>
+          <p className="text-muted-foreground">View and export all your escrow-related transactions</p>
         </div>
 
         {/* Running Totals */}
@@ -271,9 +254,7 @@ export default function TransactionsPage() {
           <div className="flex flex-wrap gap-4 items-end">
             {/* Event Type Filter */}
             <div className="flex-1 min-w-[200px]">
-              <label className="text-sm font-medium text-foreground mb-1 block">
-                Event Type
-              </label>
+              <label className="text-sm font-medium text-foreground mb-1 block">Event Type</label>
               <select
                 value={eventType}
                 onChange={(e) => {
@@ -292,9 +273,7 @@ export default function TransactionsPage() {
 
             {/* Date From */}
             <div className="flex-1 min-w-[180px]">
-              <label className="text-sm font-medium text-foreground mb-1 block">
-                From Date
-              </label>
+              <label className="text-sm font-medium text-foreground mb-1 block">From Date</label>
               <Input
                 type="date"
                 value={dateFrom}
@@ -308,9 +287,7 @@ export default function TransactionsPage() {
 
             {/* Date To */}
             <div className="flex-1 min-w-[180px]">
-              <label className="text-sm font-medium text-foreground mb-1 block">
-                To Date
-              </label>
+              <label className="text-sm font-medium text-foreground mb-1 block">To Date</label>
               <Input
                 type="date"
                 value={dateTo}
@@ -324,9 +301,7 @@ export default function TransactionsPage() {
 
             {/* Sort Order */}
             <div className="flex-1 min-w-[180px]">
-              <label className="text-sm font-medium text-foreground mb-1 block">
-                Sort By
-              </label>
+              <label className="text-sm font-medium text-foreground mb-1 block">Sort By</label>
               <select
                 value={`${sortBy}-${sortOrder}`}
                 onChange={(e) => {
@@ -343,37 +318,25 @@ export default function TransactionsPage() {
             </div>
 
             {/* Clear Filters */}
-            <Button
-              variant="outline"
-              onClick={clearFilters}
-              className="flex items-center gap-1"
-            >
+            <Button variant="outline" onClick={clearFilters} className="flex items-center gap-1">
               <Filter className="w-4 h-4" />
               Clear
             </Button>
 
             {/* Export */}
-            <ExportDropdown
-              onExport={handleExportClick}
-              disabled={events.length === 0}
-              isLoading={isExporting}
-            />
+            <ExportDropdown onExport={handleExportClick} disabled={events.length === 0} isLoading={isExporting} />
           </div>
         </div>
 
         {/* Transaction Table */}
         <div className="bg-card rounded-lg shadow overflow-hidden border border-border">
           {loading ? (
-            <div className="flex items-center justify-center py-16">
-              <Loader2 className="w-8 h-8 animate-spin text-muted-foreground" />
-            </div>
+            <TransactionTableSkeleton />
           ) : events.length === 0 ? (
             <div className="text-center py-16">
               <Calendar className="w-16 h-16 mx-auto text-muted-foreground mb-4" />
               <p className="text-foreground text-lg">No transactions found</p>
-              <p className="text-muted-foreground text-sm mt-1">
-                Try adjusting your filters or date range
-              </p>
+              <p className="text-muted-foreground text-sm mt-1">Try adjusting your filters or date range</p>
             </div>
           ) : (
             <>
@@ -381,71 +344,42 @@ export default function TransactionsPage() {
                 <table className="min-w-full divide-y divide-border">
                   <thead className="bg-muted">
                     <tr>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                        Date
-                      </th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                        Escrow
-                      </th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                        Event Type
-                      </th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                        Amount
-                      </th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                        Status
-                      </th>
-                      <th className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">
-                        Tx Hash
-                      </th>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">Date</th>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">Escrow</th>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">Event Type</th>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">Amount</th>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">Status</th>
+                      <th className="px-6 py-3 text-left text-xs font-medium text-muted-foreground uppercase tracking-wider">Tx Hash</th>
                     </tr>
                   </thead>
                   <tbody className="bg-card divide-y divide-border">
                     {events.map((event) => {
-                      const txHash =
-                        event.data?.transactionHash ||
-                        event.data?.stellarTxHash;
+                      const txHash = event.data?.transactionHash || event.data?.stellarTxHash;
 
                       return (
                         <tr key={event.id} className="hover:bg-accent/50">
                           <td className="px-6 py-4 whitespace-nowrap text-sm text-foreground">
                             {new Date(event.createdAt).toLocaleDateString()}
-                            <div className="text-xs text-muted-foreground">
-                              {new Date(event.createdAt).toLocaleTimeString()}
-                            </div>
+                            <div className="text-xs text-muted-foreground">{new Date(event.createdAt).toLocaleTimeString()}</div>
                           </td>
                           <td className="px-6 py-4">
-                            <div className="text-sm font-medium text-foreground">
-                              {event.escrow?.title || "Unknown"}
-                            </div>
-                            <div className="text-xs text-muted-foreground font-mono">
-                              {event.escrowId.slice(0, 8)}...
-                            </div>
+                            <div className="text-sm font-medium text-foreground">{event.escrow?.title || "Unknown"}</div>
+                            <div className="text-xs text-muted-foreground font-mono">{event.escrowId.slice(0, 8)}...</div>
                           </td>
                           <td className="px-6 py-4 whitespace-nowrap">
-                            <Badge
-                              className={getEventTypeColor(event.eventType)}
-                            >
-                              {formatEventType(event.eventType)}
-                            </Badge>
+                            <Badge className={getEventTypeColor(event.eventType)}>{formatEventType(event.eventType)}</Badge>
                           </td>
                           <td className="px-6 py-4 whitespace-nowrap text-sm text-foreground">
                             {event.escrow ? (
                               <div>
                                 <div className="font-medium">
-                                  {Number(event.escrow.amount).toLocaleString(
-                                    undefined,
-                                    {
-                                      minimumFractionDigits: 2,
-                                      maximumFractionDigits: 7,
-                                    },
-                                  )}
+                                  {Number(event.escrow.amount).toLocaleString(undefined, {
+                                    minimumFractionDigits: 2,
+                                    maximumFractionDigits: 7,
+                                  })}
                                 </div>
                                 <div className="text-xs text-muted-foreground">
-                                  {event.escrow.assetIssuer
-                                    ? `${event.escrow.assetCode}:${event.escrow.assetIssuer.slice(0, 8)}...`
-                                    : event.escrow.assetCode}
+                                  {event.escrow.assetIssuer ? `${event.escrow.assetCode}:${event.escrow.assetIssuer.slice(0, 8)}...` : event.escrow.assetCode}
                                 </div>
                               </div>
                             ) : (
@@ -475,9 +409,7 @@ export default function TransactionsPage() {
                                 rel="noopener noreferrer"
                                 className="text-blue-600 dark:text-blue-400 hover:underline flex items-center gap-1"
                               >
-                                <span className="font-mono text-xs">
-                                  {txHash.slice(0, 8)}...
-                                </span>
+                                <span className="font-mono text-xs">{txHash.slice(0, 8)}...</span>
                                 <ExternalLink className="w-3 h-3" />
                               </a>
                             ) : (
@@ -495,33 +427,14 @@ export default function TransactionsPage() {
               <div className="bg-muted/50 px-6 py-4 border-t border-border">
                 <div className="flex items-center justify-between">
                   <div className="text-sm text-foreground">
-                    Showing{" "}
-                    <span className="font-medium">
-                      {(page - 1) * PAGE_SIZE + 1}
-                    </span>{" "}
-                    to{" "}
-                    <span className="font-medium">
-                      {Math.min(page * PAGE_SIZE, total)}
-                    </span>{" "}
+                    Showing <span className="font-medium">{(page - 1) * PAGE_SIZE + 1}</span> to <span className="font-medium">{Math.min(page * PAGE_SIZE, total)}</span>{" "}
                     of <span className="font-medium">{total}</span> results
                   </div>
                   <div className="flex gap-2">
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() => setPage((p) => Math.max(1, p - 1))}
-                      disabled={page === 1}
-                    >
+                    <Button variant="outline" size="sm" onClick={() => setPage((p) => Math.max(1, p - 1))} disabled={page === 1}>
                       Previous
                     </Button>
-                    <Button
-                      variant="outline"
-                      size="sm"
-                      onClick={() =>
-                        setPage((p) => Math.min(totalPages, p + 1))
-                      }
-                      disabled={page === totalPages}
-                    >
+                    <Button variant="outline" size="sm" onClick={() => setPage((p) => Math.min(totalPages, p + 1))} disabled={page === totalPages}>
                       Next
                     </Button>
                   </div>
@@ -533,12 +446,7 @@ export default function TransactionsPage() {
       </div>
 
       {/* Export Modal */}
-      <ExportModal
-        isOpen={exportModalOpen}
-        onClose={() => setExportModalOpen(false)}
-        onConfirm={handleExportConfirm}
-        isLoading={isExporting}
-      />
+      <ExportModal isOpen={exportModalOpen} onClose={() => setExportModalOpen(false)} onConfirm={handleExportConfirm} isLoading={isExporting} />
     </div>
   );
 }

--- a/apps/frontend/components/ui/AdminDisputesSkeleton.tsx
+++ b/apps/frontend/components/ui/AdminDisputesSkeleton.tsx
@@ -1,0 +1,77 @@
+import { Skeleton } from "./Skeleton";
+
+export function AdminDisputesSkeleton() {
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex flex-col md:flex-row md:items-center justify-between gap-4">
+        <div className="space-y-2">
+          <Skeleton className="h-8 w-56 bg-white/10" />
+          <Skeleton className="h-4 w-80 bg-white/10" />
+        </div>
+        <Skeleton className="h-9 w-40 rounded-lg bg-white/10" />
+      </div>
+
+      {/* Split layout */}
+      <div className="grid grid-cols-1 lg:grid-cols-12 gap-6">
+        {/* Left list */}
+        <div className="lg:col-span-4 space-y-3">
+          <Skeleton className="h-4 w-24 bg-white/10" />
+          {Array.from({ length: 4 }).map((_, i) => (
+            <div key={i} className="bg-[#12121a] border border-white/5 rounded-xl p-4 space-y-3">
+              <div className="flex items-start justify-between gap-3">
+                <Skeleton className="h-4 w-36 bg-white/10 flex-1" />
+                <Skeleton className="h-5 w-14 rounded-full bg-white/10 shrink-0" />
+              </div>
+              <div className="flex justify-between">
+                <Skeleton className="h-3 w-24 bg-white/10" />
+                <Skeleton className="h-3 w-20 bg-white/10" />
+              </div>
+            </div>
+          ))}
+        </div>
+
+        {/* Right detail */}
+        <div className="lg:col-span-8 grid grid-cols-1 md:grid-cols-12 gap-6">
+          <div className="col-span-12 md:col-span-7 space-y-6">
+            <div className="bg-[#12121a] border border-white/5 rounded-xl p-5 space-y-4">
+              <Skeleton className="h-6 w-48 bg-white/10" />
+              <Skeleton className="h-4 w-full bg-white/10" />
+              <Skeleton className="h-4 w-3/4 bg-white/10" />
+              <div className="grid grid-cols-2 gap-4 bg-white/[0.02] rounded-lg p-3">
+                <div className="space-y-1">
+                  <Skeleton className="h-3 w-16 bg-white/10" />
+                  <Skeleton className="h-6 w-24 bg-white/10" />
+                </div>
+                <div className="space-y-1">
+                  <Skeleton className="h-3 w-20 bg-white/10" />
+                  <Skeleton className="h-4 w-32 bg-white/10" />
+                </div>
+              </div>
+              <Skeleton className="h-16 w-full rounded-lg bg-white/10" />
+            </div>
+            <div className="bg-[#12121a] border border-white/5 rounded-xl p-5 space-y-3">
+              <Skeleton className="h-5 w-36 bg-white/10" />
+              {Array.from({ length: 3 }).map((_, i) => (
+                <div key={i} className="flex gap-3">
+                  <Skeleton className="h-8 w-8 rounded-full bg-white/10 shrink-0" />
+                  <Skeleton className="h-14 flex-1 rounded-lg bg-white/10" />
+                </div>
+              ))}
+            </div>
+          </div>
+          <div className="col-span-12 md:col-span-5">
+            <div className="bg-[#12121a] border border-white/5 rounded-xl p-5 space-y-4">
+              <Skeleton className="h-5 w-40 bg-white/10" />
+              {Array.from({ length: 3 }).map((_, i) => (
+                <Skeleton key={i} className="h-12 w-full rounded-lg bg-white/10" />
+              ))}
+              <Skeleton className="h-24 w-full rounded-lg bg-white/10" />
+              <Skeleton className="h-10 w-full rounded-lg bg-white/10" />
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/components/ui/AdminOverviewSkeleton.tsx
+++ b/apps/frontend/components/ui/AdminOverviewSkeleton.tsx
@@ -1,0 +1,75 @@
+import { Skeleton } from "./Skeleton";
+
+export function AdminOverviewSkeleton() {
+  return (
+    <div className="space-y-6">
+      {/* Page header */}
+      <div className="space-y-2">
+        <Skeleton className="h-8 w-48 bg-white/10" />
+        <Skeleton className="h-4 w-72 bg-white/10" />
+      </div>
+
+      {/* Stat cards */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="bg-[#12121a] border border-white/5 rounded-xl p-5 space-y-4">
+            <div className="flex items-start justify-between">
+              <Skeleton className="h-10 w-10 rounded-lg bg-white/10" />
+              <Skeleton className="h-6 w-14 rounded-full bg-white/10" />
+            </div>
+            <Skeleton className="h-8 w-24 bg-white/10" />
+            <Skeleton className="h-3 w-32 bg-white/10" />
+          </div>
+        ))}
+      </div>
+
+      {/* Charts row */}
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-4">
+        <div className="lg:col-span-2 bg-[#12121a] border border-white/5 rounded-xl p-6 space-y-4">
+          <Skeleton className="h-5 w-48 bg-white/10" />
+          <Skeleton className="h-4 w-64 bg-white/10" />
+          <div className="flex items-end gap-2 h-40">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className="flex-1 flex flex-col items-center gap-2">
+                <div style={{ height: `${40 + i * 10}%` }} className="w-full">
+                  <Skeleton className="w-full h-full bg-white/10" />
+                </div>
+                <Skeleton className="h-2 w-6 bg-white/10" />
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className="bg-[#12121a] border border-white/5 rounded-xl p-6 space-y-4">
+          <Skeleton className="h-5 w-36 bg-white/10" />
+          {Array.from({ length: 3 }).map((_, i) => (
+            <div key={i} className="space-y-2">
+              <div className="flex justify-between">
+                <Skeleton className="h-3 w-16 bg-white/10" />
+                <Skeleton className="h-3 w-20 bg-white/10" />
+              </div>
+              <Skeleton className="h-1.5 w-full rounded-full bg-white/10" />
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Activity row */}
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        {Array.from({ length: 2 }).map((_, i) => (
+          <div key={i} className="bg-[#12121a] border border-white/5 rounded-xl p-6 space-y-4">
+            <Skeleton className="h-5 w-32 bg-white/10" />
+            {Array.from({ length: 4 }).map((_, j) => (
+              <div key={j} className="flex items-center gap-3">
+                <Skeleton className="h-8 w-8 rounded-lg bg-white/10 shrink-0" />
+                <div className="flex-1 space-y-1.5">
+                  <Skeleton className="h-3 w-48 bg-white/10" />
+                  <Skeleton className="h-2 w-16 bg-white/10" />
+                </div>
+              </div>
+            ))}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/components/ui/AdminTableSkeleton.tsx
+++ b/apps/frontend/components/ui/AdminTableSkeleton.tsx
@@ -1,0 +1,73 @@
+import { Skeleton } from "./Skeleton";
+
+export function AdminTableSkeleton({ rows = 8 }: { rows?: number }) {
+  return (
+    <div className="space-y-5">
+      {/* Filter pills */}
+      <div className="flex items-center gap-2 overflow-x-auto pb-1">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <Skeleton key={i} className="h-9 w-20 rounded-lg bg-white/10 shrink-0" />
+        ))}
+      </div>
+
+      {/* Desktop table */}
+      <div className="hidden sm:block bg-[#12121a] border border-white/5 rounded-xl overflow-hidden">
+        <table className="w-full">
+          <thead>
+            <tr className="border-b border-white/5">
+              {Array.from({ length: 6 }).map((_, i) => (
+                <th key={i} className="px-5 py-3">
+                  <Skeleton className="h-3 w-16 bg-white/10" />
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {Array.from({ length: rows }).map((_, i) => (
+              <tr key={i} className="border-b border-white/[0.03]">
+                <td className="px-5 py-4 space-y-1">
+                  <Skeleton className="h-4 w-36 bg-white/10" />
+                  <Skeleton className="h-2 w-24 bg-white/10" />
+                </td>
+                <td className="px-5 py-4">
+                  <Skeleton className="h-4 w-24 bg-white/10" />
+                </td>
+                <td className="px-5 py-4">
+                  <Skeleton className="h-6 w-20 rounded-full bg-white/10" />
+                </td>
+                <td className="px-5 py-4">
+                  <Skeleton className="h-3 w-16 bg-white/10" />
+                </td>
+                <td className="px-5 py-4">
+                  <Skeleton className="h-3 w-20 bg-white/10" />
+                </td>
+                <td className="px-5 py-4 text-right">
+                  <Skeleton className="h-4 w-12 ml-auto bg-white/10" />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Mobile cards */}
+      <div className="sm:hidden space-y-3">
+        {Array.from({ length: 4 }).map((_, i) => (
+          <div key={i} className="bg-white/[0.02] border border-white/5 rounded-xl p-4 space-y-3">
+            <div className="flex items-start justify-between gap-2">
+              <div className="space-y-1.5 flex-1">
+                <Skeleton className="h-4 w-40 bg-white/10" />
+                <Skeleton className="h-2 w-24 bg-white/10" />
+              </div>
+              <Skeleton className="h-6 w-20 rounded-full bg-white/10 shrink-0" />
+            </div>
+            <div className="flex items-center justify-between">
+              <Skeleton className="h-4 w-28 bg-white/10" />
+              <Skeleton className="h-9 w-16 rounded-lg bg-white/10" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/components/ui/NotificationListSkeleton.tsx
+++ b/apps/frontend/components/ui/NotificationListSkeleton.tsx
@@ -1,0 +1,20 @@
+import { Skeleton } from "./Skeleton";
+
+export function NotificationListSkeleton() {
+  return (
+    <div className="bg-[#12121a] border border-white/5 rounded-xl overflow-hidden shadow-xl">
+      <div className="divide-y divide-white/5">
+        {Array.from({ length: 6 }).map((_, i) => (
+          <div key={i} className="flex items-start gap-4 p-5">
+            <Skeleton className="h-8 w-8 rounded-full shrink-0 mt-0.5 bg-white/10" />
+            <div className="flex-1 space-y-2">
+              <Skeleton className="h-3 w-40 bg-white/10" />
+              <Skeleton className="h-3 w-64 bg-white/10" />
+              <Skeleton className="h-2 w-24 bg-white/10" />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/components/ui/TransactionTableSkeleton.tsx
+++ b/apps/frontend/components/ui/TransactionTableSkeleton.tsx
@@ -1,0 +1,55 @@
+import { Skeleton } from "./Skeleton";
+
+export function TransactionTableSkeleton() {
+  return (
+    <div className="bg-card rounded-lg shadow overflow-hidden border border-border">
+      {/* Summary cards */}
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 p-4 border-b border-border">
+        {Array.from({ length: 3 }).map((_, i) => (
+          <div key={i} className="bg-card rounded-lg p-6 border border-border space-y-3">
+            <Skeleton className="h-4 w-24" />
+            <Skeleton className="h-8 w-36" />
+          </div>
+        ))}
+      </div>
+      {/* Table rows */}
+      <div className="overflow-x-auto">
+        <table className="min-w-full">
+          <thead>
+            <tr className="bg-muted">
+              {Array.from({ length: 6 }).map((_, i) => (
+                <th key={i} className="px-6 py-3">
+                  <Skeleton className="h-3 w-16" />
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {Array.from({ length: 8 }).map((_, i) => (
+              <tr key={i} className="border-t border-border">
+                <td className="px-6 py-4">
+                  <Skeleton className="h-4 w-20" />
+                </td>
+                <td className="px-6 py-4">
+                  <Skeleton className="h-4 w-32" />
+                </td>
+                <td className="px-6 py-4">
+                  <Skeleton className="h-5 w-20 rounded-full" />
+                </td>
+                <td className="px-6 py-4">
+                  <Skeleton className="h-4 w-24" />
+                </td>
+                <td className="px-6 py-4">
+                  <Skeleton className="h-5 w-16 rounded-full" />
+                </td>
+                <td className="px-6 py-4">
+                  <Skeleton className="h-4 w-20" />
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/apps/frontend/pnpm-lock.yaml
+++ b/apps/frontend/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@tanstack/react-query':
         specifier: ^5.90.20
         version: 5.101.2(react@19.1.0)
+      axios:
+        specifier: ^1.18.1
+        version: 1.18.1
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -29,6 +32,12 @@ importers:
       framer-motion:
         specifier: ^12.29.2
         version: 12.42.0(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      jspdf:
+        specifier: ^4.2.1
+        version: 4.2.1
+      jspdf-autotable:
+        specifier: ^5.0.8
+        version: 5.0.8(jspdf@4.2.1)
       lucide-react:
         specifier: ^0.562.0
         version: 0.562.0(react@19.1.0)
@@ -511,105 +520,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -835,28 +828,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@15.5.7':
     resolution: {integrity: sha512-nfymt+SE5cvtTrG9u1wdoxBr9bVB7mtKTcj0ltRn6gkP/2Nu1zM5ei8rwP9qKQP0Y//umK+TtkKgNtfboBxRrw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@15.5.7':
     resolution: {integrity: sha512-hvXcZvCaaEbCZcVzcY7E1uXN9xWZfFvkNHwbe/n4OkRhFWrs1J1QV+4U1BN06tXLdaS4DazEGXwgqnu/VMcmqw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@15.5.7':
     resolution: {integrity: sha512-4IUO539b8FmF0odY6/SqANJdgwn1xs1GkPO5doZugwZ3ETF6JUdckk7RGmsfSf7ws8Qb2YB5It33mvNL/0acqA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@15.5.7':
     resolution: {integrity: sha512-CpJVTkYI3ZajQkC5vajM7/ApKJUOlm6uP4BknM3XKvJ7VXAvCqSjSLmM0LKdYzn6nBJVSjdclx8nYJSa3xlTgQ==}
@@ -1685,28 +1674,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.1':
     resolution: {integrity: sha512-Bwv9KwOvE0VKa86xPFif9b9c3Y1NxOV1P0gLti/IYaWEsQYZXDlxfGEtA8mdDZ7SG3wyNXAWYT5SIn3giL57oA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.1':
     resolution: {integrity: sha512-Ymi8O8T15HYQdOUWUtTI6ldN0neHP85FC+Qz32xTcZ7iJXtem/x8ITev0o1e9e5rkqj4lONZfTRLvkmin1+tKg==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.1':
     resolution: {integrity: sha512-M+P/91qJ6uILLw4k2G93GMDRAXj61SMvFQYt39AqvUqYgExXpLL5aepfns7sj4HiAQeolirQF9E0lzRvdf4zPQ==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.1':
     resolution: {integrity: sha512-zsM8uOeqvVGHsAXsJxsT28ttosFahLJKCLOTUBqRAtKnVgGSRitds9T432QiT8b77Yga7JIBkulIRRlJPtYhRA==}
@@ -1830,6 +1815,12 @@ packages:
   '@types/node@20.19.43':
     resolution: {integrity: sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==}
 
+  '@types/pako@2.0.4':
+    resolution: {integrity: sha512-VWDCbrLeVXJM9fihYodcLiIv0ku+AlOa/TQ1SvYOaBuyrSKgEcro95LJyIsJ4vSo6BXIxOKxiJAat04CmST9Fw==}
+
+  '@types/raf@3.4.3':
+    resolution: {integrity: sha512-c4YAvMedbPZ5tEyxzQdMoOhhJ4RD3rngZIdwC2/qDN3d7JpEhB6fiBRKVY1lg5B7Wk+uPBjn5f39j1/2MY1oOw==}
+
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
@@ -1849,6 +1840,9 @@ packages:
 
   '@types/tough-cookie@4.0.5':
     resolution: {integrity: sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==}
+
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
 
   '@types/validate-npm-package-name@4.0.2':
     resolution: {integrity: sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==}
@@ -1960,61 +1954,51 @@ packages:
     resolution: {integrity: sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.12.2':
     resolution: {integrity: sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-loong64-gnu@1.12.2':
     resolution: {integrity: sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-loong64-musl@1.12.2':
     resolution: {integrity: sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.12.2':
     resolution: {integrity: sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.12.2':
     resolution: {integrity: sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.12.2':
     resolution: {integrity: sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.12.2':
     resolution: {integrity: sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.12.2':
     resolution: {integrity: sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.12.2':
     resolution: {integrity: sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-openharmony-arm64@1.12.2':
     resolution: {integrity: sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==}
@@ -2265,6 +2249,10 @@ packages:
     resolution: {integrity: sha512-n3TkB02ixgBOhTvANakDb4xaMXnYUVkNoRFJjQflcqMQhyEKxEHdj3E6N8t8sUQ0mjH/3/JxzlXuz3ul/J90pQ==}
     engines: {node: '>=0.12.0'}
 
+  base64-arraybuffer@1.0.2:
+    resolution: {integrity: sha512-I3yl4r9QB5ZRY3XuJVEPfc2XhZO6YweFPI+UovAzn+8/hb3oJ6lnysaFcjVpkCPfVWFUDvoZ8kmVDP7WyRtYtQ==}
+    engines: {node: '>= 0.6.0'}
+
   base64-js@1.5.1:
     resolution: {integrity: sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==}
 
@@ -2345,6 +2333,10 @@ packages:
 
   caniuse-lite@1.0.30001799:
     resolution: {integrity: sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==}
+
+  canvg@3.0.11:
+    resolution: {integrity: sha512-5ON+q7jCTgMp9cjpu4Jo6XbvfYwSB2Ow3kzHKfIyJfaCAOHLbdKPQqGKgfED/R5B+3TFFfe8pegYA+b423SRyA==}
+    engines: {node: '>=10.0.0'}
 
   chalk@4.1.2:
     resolution: {integrity: sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==}
@@ -2470,6 +2462,9 @@ packages:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
 
+  core-js@3.49.0:
+    resolution: {integrity: sha512-es1U2+YTtzpwkxVLwAFdSpaIMyQaq0PBgm3YD1W3Qpsn1NAmO3KSgZfu+oGSWVu6NvLHoHCV/aYcsE5wiB7ALg==}
+
   cors@2.8.6:
     resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
     engines: {node: '>= 0.10'}
@@ -2489,6 +2484,9 @@ packages:
   cross-spawn@7.0.6:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
+
+  css-line-break@2.1.0:
+    resolution: {integrity: sha512-FHcKFCZcAha3LwfVBhCQbW2nCNbkZXn7KVUJcsT5/P8YmfsVja0FMPJr0B903j/E69HUphKiV9iQArX8SDYA4w==}
 
   css.escape@1.5.1:
     resolution: {integrity: sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==}
@@ -2638,6 +2636,9 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dompurify@3.4.12:
+    resolution: {integrity: sha512-zQvGet8Z2sWbQhCmfFz/T5QWH2oBmjnqK3qvOjaqaNLrLEF912WamU+ohnTp0TCep/MFVHpdJuCZEdFOdTnEFg==}
 
   dot-prop@6.0.1:
     resolution: {integrity: sha512-tE7ztYzXHIeyvc7N+hR3oi7FIbf/NIjVP9hmAt3yMXzrQ072/fpjGLx2GxNxGxUl5V73MEqYzioOMoVhGMJ5cA==}
@@ -2951,6 +2952,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-png@6.4.0:
+    resolution: {integrity: sha512-kAqZq1TlgBjZcLr5mcN6NP5Rv4V2f22z00c3g8vRrwkcqjerx7BEhPbOnWCPqaHUl2XWQBJQvOT/FQhdMT7X/Q==}
+
   fast-string-truncated-width@3.0.3:
     resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
 
@@ -2984,6 +2988,9 @@ packages:
   fetch-blob@3.2.0:
     resolution: {integrity: sha512-7yAQpD2UMJzLi1Dqv7qFYnPbaPx7ZfFK6PiIxQ4PfkGPyNyl2Ugx+a/umUonmKqjhM4DnfbMvdX6otXq83soQQ==}
     engines: {node: ^12.20 || >= 14.13}
+
+  fflate@0.8.3:
+    resolution: {integrity: sha512-tbZNuJrLwGUp3zshBtdy4W+ORxZuIh8a5ilyIEQDC5rY1f3U20JMry0Ll3WBzU58EZKsEuJFXhb5gwv8CsPvgA==}
 
   figures@6.1.0:
     resolution: {integrity: sha512-d+l3qxjSesT4V7v2fh+QnmFnUWv9lSpjarhShNTgBOfA0ttejbQUAlHLitbjkoRiDulW0OPoQPYIGhIC8ohejg==}
@@ -3231,6 +3238,10 @@ packages:
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
+  html2canvas@1.4.1:
+    resolution: {integrity: sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==}
+    engines: {node: '>=8.0.0'}
+
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
@@ -3305,6 +3316,9 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  iobuffer@5.4.0:
+    resolution: {integrity: sha512-DRebOWuqDvxunfkNJAlc3IzWIPD5xVxwUNbHr7xKB8E6aLJxIPfNX3CoMJghcFjpv6RWQsrcJbghtEwSPoJqMA==}
 
   ip-address@10.2.0:
     resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
@@ -3755,6 +3769,14 @@ packages:
   jsonfile@6.2.1:
     resolution: {integrity: sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==}
 
+  jspdf-autotable@5.0.8:
+    resolution: {integrity: sha512-Hy05N86yBO7CXBrnSLOge7i1ZYpKH2DjQ94iybaP7vBhSInjvRBgDc99ngKzSbSO8Jc98ZCally8I6n0tj2RJQ==}
+    peerDependencies:
+      jspdf: ^2 || ^3 || ^4
+
+  jspdf@4.2.1:
+    resolution: {integrity: sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==}
+
   jsx-ast-utils@3.3.5:
     resolution: {integrity: sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ==}
     engines: {node: '>=4.0'}
@@ -3820,28 +3842,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -4206,6 +4224,9 @@ packages:
   package-manager-detector@1.6.0:
     resolution: {integrity: sha512-61A5ThoTiDG/C8s8UMZwSorAGwMJ0ERVGj2OjoW5pAalsNOg15+iQiPzrLJ4jhZ1HJzmC2PIHT2oEiH3R5fzNA==}
 
+  pako@2.2.0:
+    resolution: {integrity: sha512-zJq6RP/5q+TO2OpFV3FHzlPnFjmkb7Nc99a5SNjJE+uu/PkpChs+NIZSSzbBoD+6kjiISXjfYdwj1ZRQ81dz/w==}
+
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
@@ -4260,6 +4281,9 @@ packages:
 
   path-to-regexp@8.4.2:
     resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
+
+  performance-now@2.1.0:
+    resolution: {integrity: sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -4389,6 +4413,9 @@ packages:
       '@types/react-dom':
         optional: true
 
+  raf@3.4.1:
+    resolution: {integrity: sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==}
+
   randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
 
@@ -4473,6 +4500,9 @@ packages:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
     engines: {node: '>= 0.4'}
 
+  regenerator-runtime@0.13.11:
+    resolution: {integrity: sha512-kY1AZVr2Ra+t+piVaJ4gxaFaReZVH40AKNo7UCX6W+dEwBo/2oZJzqfuN1qLq1oL45o56cPaTXELwrTh8Fpggg==}
+
   regexp.prototype.flags@1.5.4:
     resolution: {integrity: sha512-dYqgNSZbDwkaJ2ceRd9ojCGjBq+mOm9LmtXnAnEGyHhN/5R7iDW2TRw3h+o/jCFxus3P2LfWIIiwowAjANm7IA==}
     engines: {node: '>= 0.4'}
@@ -4523,6 +4553,10 @@ packages:
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rgbcolor@1.0.1:
+    resolution: {integrity: sha512-9aZLIrhRaD97sgVhtJOW6ckOEh6/GnvQtdVNfdZ6s67+3/XwLS9lBcQYzEEhYVeUowN7pRzMLsyGhK2i/xvWbw==}
+    engines: {node: '>= 0.8.15'}
 
   rimraf@3.0.2:
     resolution: {integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==}
@@ -4697,6 +4731,10 @@ packages:
     resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
     engines: {node: '>=10'}
 
+  stackblur-canvas@2.7.0:
+    resolution: {integrity: sha512-yf7OENo23AGJhBriGx0QivY5JP6Y1HbrrDI6WLt6C5auYZXlQrheoY8hD4ibekFKz1HOfE48Ww8kMWMnJD/zcQ==}
+    engines: {node: '>=0.1.14'}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
@@ -4828,6 +4866,10 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  svg-pathdata@6.0.3:
+    resolution: {integrity: sha512-qsjeeq5YjBZ5eMdFuUa4ZosMLxgr5RZ+F+Y1OrDhuOCEInRMA3x74XdBtggJcj9kOeInz0WE+LgCPDkZFlBYJw==}
+    engines: {node: '>=12.0.0'}
+
   symbol-tree@3.2.4:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
 
@@ -4858,6 +4900,9 @@ packages:
   test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
     engines: {node: '>=8'}
+
+  text-segmentation@1.0.3:
+    resolution: {integrity: sha512-iOiPUo/BGnZ6+54OsWxZidGCsdU8YbE4PSpdPinp7DeMtUJNJBoJ/ouUSTJjHkh1KntHaltHl/gDs2FC4i5+Nw==}
 
   text-table@0.2.0:
     resolution: {integrity: sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==}
@@ -5071,6 +5116,9 @@ packages:
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  utrie@1.0.2:
+    resolution: {integrity: sha512-1MLa5ouZiOmQzUbjbu9VmjLzn1QLXBhwpUa7kdLUQK+KQ5KA9I1vk5U4YHe/X2Ch7PYnJfWuWT+VbuxbGwljhw==}
 
   v8-compile-cache-lib@3.0.1:
     resolution: {integrity: sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==}
@@ -7088,6 +7136,11 @@ snapshots:
     dependencies:
       undici-types: 6.21.0
 
+  '@types/pako@2.0.4': {}
+
+  '@types/raf@3.4.3':
+    optional: true
+
   '@types/react-dom@19.2.3(@types/react@19.2.17)':
     dependencies:
       '@types/react': 19.2.17
@@ -7105,6 +7158,9 @@ snapshots:
   '@types/statuses@2.0.6': {}
 
   '@types/tough-cookie@4.0.5': {}
+
+  '@types/trusted-types@2.0.7':
+    optional: true
 
   '@types/validate-npm-package-name@4.0.2': {}
 
@@ -7534,6 +7590,9 @@ snapshots:
 
   base32.js@0.1.0: {}
 
+  base64-arraybuffer@1.0.2:
+    optional: true
+
   base64-js@1.5.1: {}
 
   baseline-browser-mapping@2.10.40: {}
@@ -7626,6 +7685,18 @@ snapshots:
   camelcase@6.3.0: {}
 
   caniuse-lite@1.0.30001799: {}
+
+  canvg@3.0.11:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      '@types/raf': 3.4.3
+      core-js: 3.49.0
+      raf: 3.4.1
+      regenerator-runtime: 0.13.11
+      rgbcolor: 1.0.1
+      stackblur-canvas: 2.7.0
+      svg-pathdata: 6.0.3
+    optional: true
 
   chalk@4.1.2:
     dependencies:
@@ -7721,6 +7792,9 @@ snapshots:
 
   cookie@1.1.1: {}
 
+  core-js@3.49.0:
+    optional: true
+
   cors@2.8.6:
     dependencies:
       object-assign: 4.1.1
@@ -7742,6 +7816,11 @@ snapshots:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
+
+  css-line-break@2.1.0:
+    dependencies:
+      utrie: 1.0.2
+    optional: true
 
   css.escape@1.5.1: {}
 
@@ -7855,6 +7934,11 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  dompurify@3.4.12:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+    optional: true
 
   dot-prop@6.0.1:
     dependencies:
@@ -8364,6 +8448,12 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-png@6.4.0:
+    dependencies:
+      '@types/pako': 2.0.4
+      iobuffer: 5.4.0
+      pako: 2.2.0
+
   fast-string-truncated-width@3.0.3: {}
 
   fast-string-width@3.0.2:
@@ -8396,6 +8486,8 @@ snapshots:
     dependencies:
       node-domexception: 1.0.0
       web-streams-polyfill: 3.3.3
+
+  fflate@0.8.3: {}
 
   figures@6.1.0:
     dependencies:
@@ -8639,6 +8731,12 @@ snapshots:
 
   html-escaper@2.0.2: {}
 
+  html2canvas@1.4.1:
+    dependencies:
+      css-line-break: 2.1.0
+      text-segmentation: 1.0.3
+    optional: true
+
   http-errors@2.0.1:
     dependencies:
       depd: 2.0.0
@@ -8714,6 +8812,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.4
       side-channel: 1.1.1
+
+  iobuffer@5.4.0: {}
 
   ip-address@10.2.0: {}
 
@@ -9333,6 +9433,21 @@ snapshots:
     optionalDependencies:
       graceful-fs: 4.2.11
 
+  jspdf-autotable@5.0.8(jspdf@4.2.1):
+    dependencies:
+      jspdf: 4.2.1
+
+  jspdf@4.2.1:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      fast-png: 6.4.0
+      fflate: 0.8.3
+    optionalDependencies:
+      canvg: 3.0.11
+      core-js: 3.49.0
+      dompurify: 3.4.12
+      html2canvas: 1.4.1
+
   jsx-ast-utils@3.3.5:
     dependencies:
       array-includes: 3.1.9
@@ -9769,6 +9884,8 @@ snapshots:
 
   package-manager-detector@1.6.0: {}
 
+  pako@2.2.0: {}
+
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
@@ -9810,6 +9927,9 @@ snapshots:
   path-to-regexp@6.3.0: {}
 
   path-to-regexp@8.4.2: {}
+
+  performance-now@2.1.0:
+    optional: true
 
   picocolors@1.1.1: {}
 
@@ -9981,6 +10101,11 @@ snapshots:
       '@types/react': 19.2.17
       '@types/react-dom': 19.2.3(@types/react@19.2.17)
 
+  raf@3.4.1:
+    dependencies:
+      performance-now: 2.1.0
+    optional: true
+
   randombytes@2.1.0:
     dependencies:
       safe-buffer: 5.2.1
@@ -10070,6 +10195,9 @@ snapshots:
       get-proto: 1.0.1
       which-builtin-type: 1.2.1
 
+  regenerator-runtime@0.13.11:
+    optional: true
+
   regexp.prototype.flags@1.5.4:
     dependencies:
       call-bind: 1.0.9
@@ -10122,6 +10250,9 @@ snapshots:
   rettime@0.11.11: {}
 
   reusify@1.1.0: {}
+
+  rgbcolor@1.0.1:
+    optional: true
 
   rimraf@3.0.2:
     dependencies:
@@ -10402,6 +10533,9 @@ snapshots:
     dependencies:
       escape-string-regexp: 2.0.0
 
+  stackblur-canvas@2.7.0:
+    optional: true
+
   statuses@2.0.2: {}
 
   stdin-discarder@0.1.0:
@@ -10557,6 +10691,9 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  svg-pathdata@6.0.3:
+    optional: true
+
   symbol-tree@3.2.4: {}
 
   synckit@0.11.13:
@@ -10578,6 +10715,11 @@ snapshots:
       '@istanbuljs/schema': 0.1.6
       glob: 7.2.3
       minimatch: 3.1.5
+
+  text-segmentation@1.0.3:
+    dependencies:
+      utrie: 1.0.2
+    optional: true
 
   text-table@0.2.0: {}
 
@@ -10816,6 +10958,11 @@ snapshots:
       '@types/react': 19.2.17
 
   util-deprecate@1.0.2: {}
+
+  utrie@1.0.2:
+    dependencies:
+      base64-arraybuffer: 1.0.2
+    optional: true
 
   v8-compile-cache-lib@3.0.1: {}
 


### PR DESCRIPTION
## Description

Resolves inconsistent loading states across the app where some pages showed
blank content and others showed a generic spinner while data was fetching.
This PR introduces unified skeleton loading states across all data-heavy pages,
matching the shape and layout of the actual content they replace.

## Notification page skeleton loading state
<img width="1376" height="834" alt="Screenshot 2026-07-30 112923" src="https://github.com/user-attachments/assets/c8ef11e9-c1ed-4f53-8893-7874dbf694c1" />

## Related Issue

Closes #478

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Changes Made

### New Skeleton Components (`apps/frontend/components/ui/`)

- **`TransactionTableSkeleton.tsx`** — Mimics the summary cards + 8-row
  table layout of the Transactions page
- **`NotificationListSkeleton.tsx`** — Mimics the notification list items
  with avatar, title, body, and timestamp placeholders
- **`AdminOverviewSkeleton.tsx`** — Mimics the stat cards grid, bar chart,
  role distribution panel, and activity feed of the Admin Overview page
- **`AdminTableSkeleton.tsx`** — Reusable skeleton for admin table pages;
  renders filter pills, desktop table rows, and mobile card fallbacks
- **`AdminDisputesSkeleton.tsx`** — Mimics the split-panel dispute layout
  with list on the left and detail + resolution form on the right

### Pages Updated

| Page | File | Before | After |
|---|---|---|---|
| Dashboard | `app/dashboard/page.tsx` | Plain "Loading Dashboard..." text | `EscrowCardSkeleton` + `ActivityFeedSkeleton` in Suspense fallback |
| Transactions | `app/transactions/page.tsx` | `Loader2` spinner | `TransactionTableSkeleton` |
| Notifications | `app/notifications/page.tsx` | Spinner + "Fetching event feed..." text | `NotificationListSkeleton` |
| Admin Overview | `app/admin/page.tsx` | `Loader2` spinner | `AdminOverviewSkeleton` |
| Admin Escrows | `app/admin/escrows/page.tsx` | `Loader2` spinner | `AdminTableSkeleton` |
| Admin Disputes | `app/admin/disputes/page.tsx` | `Loader2` spinner | `AdminDisputesSkeleton` |
| Escrow Detail | `app/escrow/[id]/page.tsx` | ✅ Already using `EscrowDetailSkeleton` | No change needed |

### No Changes Needed

The following already had correct skeleton implementations:
- `components/dashboard/EscrowList.tsx` — already uses `EscrowCardSkeleton`
- `components/common/ActivityFeed.tsx` — already uses `ActivityFeedSkeleton`
- `app/escrow/[id]/page.tsx` — already uses `EscrowDetailSkeleton`

## Testing Done

- [x] Manually tested all 6 updated pages with Chrome DevTools Network
  throttled to Slow 3G to force skeleton visibility
- [x] Verified skeletons match the shape and column count of actual content
- [x] Verified no flash of empty/blank content before data loads
- [x] Confirmed existing skeleton implementations still work correctly
- [x] No TypeScript or lint errors

## Checklist

- [x] My code follows the project's coding standards
- [x] I have run lint and tests locally
- [x] I have updated documentation as needed
- [x] I have read the CONTRIBUTING.md file
- [x] Skeletons are visually consistent across the app
- [x] Skeletons match the shape of actual content
- [x] No flash of empty content before data loads
- [x] All data-heavy pages now show skeleton loading states